### PR TITLE
fix(mcp): interpolate env vars in server args

### DIFF
--- a/src/pincer/mcp/config.py
+++ b/src/pincer/mcp/config.py
@@ -169,6 +169,10 @@ def _interpolate_dict(d: dict[str, str]) -> dict[str, str]:
     return {k: _interpolate_env(v) for k, v in d.items()}
 
 
+def _interpolate_list(values: list[str]) -> list[str]:
+    return [_interpolate_env(v) for v in values]
+
+
 def _parse_server_from_toml(raw: dict[str, Any]) -> MCPServerConfig:
     """Parse a single [[mcp.servers]] TOML entry."""
     transport = MCPTransport(raw.get("transport", "stdio"))
@@ -183,7 +187,7 @@ def _parse_server_from_toml(raw: dict[str, Any]) -> MCPServerConfig:
         transport=transport,
         enabled=raw.get("enabled", True),
         command=raw.get("command"),
-        args=raw.get("args", []),
+        args=_interpolate_list(raw.get("args", [])),
         env=env,
         url=raw.get("url"),
         headers=headers,
@@ -304,7 +308,7 @@ def _load_env_servers() -> list[MCPServerConfig]:
 
         # Parse args: comma-separated
         args_str = os.environ.get(f"{prefix}ARGS", "")
-        args = [a.strip() for a in args_str.split(",") if a.strip()] if args_str else []
+        args = _interpolate_list([a.strip() for a in args_str.split(",") if a.strip()]) if args_str else []
 
         # Parse env: PINCER_MCP_SERVER_N_ENV_VARNAME=value
         env: dict[str, str] = {}

--- a/tests/test_mcp_config.py
+++ b/tests/test_mcp_config.py
@@ -294,6 +294,36 @@ Authorization = "Bearer ${MY_TOKEN}"
     assert cfg.servers[0].headers["Authorization"] == "Bearer secret123"
 
 
+def test_env_var_in_toml_args_resolved(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("PINCER_SRC_DIR", "/workspace/src")
+    monkeypatch.setenv("NEWSAPI_KEY", "abc123")
+    toml_content = """
+[mcp]
+[[mcp.servers]]
+name = "newsapi"
+transport = "stdio"
+command = "python"
+args = ["${PINCER_SRC_DIR}/pincer-mcps/newsapi_server.py", "--api-key=${NEWSAPI_KEY}", "${MISSING_VAR}"]
+"""
+    (tmp_path / "pincer.toml").write_text(toml_content)
+    cfg = load_mcp_config(tmp_path)
+    assert cfg.servers[0].args == [
+        "/workspace/src/pincer-mcps/newsapi_server.py",
+        "--api-key=abc123",
+        "${MISSING_VAR}",
+    ]
+
+
+def test_env_server_args_interpolated(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("PINCER_SCRIPT", "server.py")
+    monkeypatch.setenv("PINCER_MCP_SERVER_1_NAME", "envargs")
+    monkeypatch.setenv("PINCER_MCP_SERVER_1_TRANSPORT", "stdio")
+    monkeypatch.setenv("PINCER_MCP_SERVER_1_COMMAND", "python")
+    monkeypatch.setenv("PINCER_MCP_SERVER_1_ARGS", "${PINCER_SCRIPT},--mode=test")
+    cfg = load_mcp_config(tmp_path)
+    assert cfg.servers[0].args == ["server.py", "--mode=test"]
+
+
 # ── pincer.local.toml merge ───────────────────────────────────────────────────
 
 


### PR DESCRIPTION
## Summary

Fix MCP server argument configuration so `${VAR}` references in `args` are resolved the same way existing env/header config values are resolved.

This lets users keep machine-specific MCP script paths out of `pincer.toml`, for example:

```toml
args = ["${PINCER_SRC_DIR}/pincer-mcps/newsapi_server.py"]
```

## Changes

- Added list interpolation for MCP config values.
- Applied it to TOML `[[mcp.servers]].args`.
- Applied it to comma-separated `PINCER_MCP_SERVER_N_ARGS`.
- Added regression tests for TOML args and env-defined server args.

## Tests

- `uv run pytest tests/test_mcp_config.py -q`
- `uv run pytest tests/test_mcp_client.py tests/test_mcp_manager.py -q`
- `uv run ruff check src/pincer/mcp/config.py tests/test_mcp_config.py`
- `uv run mypy src/pincer/mcp/config.py`
- `git diff --check`

Additional note: I also sampled the full suite with `uv run pytest -q`. The new MCP config tests passed, but the full suite has existing Windows/local-environment failures unrelated to this patch, including chmod permission assertions, default encoding reads, missing tzdata on Windows, and sandbox/MCP integration environment issues.

Closes #107.
