### PR TITLE
fix(mcp): resolve relative args against config dir, fix server filenames

### DIFF
--- a/pincer.toml
+++ b/pincer.toml
@@ -124,7 +124,7 @@ expose_tools = [
 name = "memory"
 transport = "stdio"
 command = "python"
-args = ["/app/src/sqlite-vec-memory-mcp/server.py"]
+args = ["src/sqlite-vec-memory-mcp/memory_server.py"]
 env = { MEMORY_DB_PATH = "/app/data/sqlite_vec.db" }
 sandbox = true
 
@@ -132,36 +132,36 @@ sandbox = true
 name      = "newsapi"
 transport = "stdio"
 command = "python"
-args = ["/app/src/pincer-mcps/newsapi_server.py"]
+args = ["src/pincer-mcps/newsapi_server.py"]
 env = { API_KEY="${PINCER_NEWSAPI_KEY}" }
 
 [[mcp.servers]]
 name      = "openweathermap"
 transport = "stdio"
 command = "python"
-args = ["/app/src/pincer-mcps/openweathermap_server.py"]
+args = ["src/pincer-mcps/openweathermap_server.py"]
 env = { API_KEY="${PINCER_OPENWEATHERMAP_API_KEY}" }
 
 [[mcp.servers]]
 name      = "pomodoro"
 transport = "stdio"
 command = "python"
-args = ["/app/src/pomodoro-mcp/server.py"]
+args = ["src/pomodoro-mcp/pomodoro_server.py"]
 
 [[mcp.servers]]
 name      = "stock_price"
 transport = "stdio"
 command = "python"
-args = ["/app/src/pincer-mcps/stock_price_server.py"]
+args = ["src/pincer-mcps/stock_price_server.py"]
 
 [[mcp.servers]]
 name      = "summarize"
 transport = "stdio"
 command = "python"
-args = ["/app/src/pincer-mcps/summarize_server.py"]
+args = ["src/pincer-mcps/summarize_server.py"]
 
 [[mcp.servers]]
 name      = "translate"
 transport = "stdio"
 command = "python"
-args = ["/app/src/pincer-mcps/translate_server.py"]
+args = ["src/pincer-mcps/translate_server.py"]

--- a/src/pincer/mcp/config.py
+++ b/src/pincer/mcp/config.py
@@ -169,7 +169,14 @@ def _interpolate_dict(d: dict[str, str]) -> dict[str, str]:
     return {k: _interpolate_env(v) for k, v in d.items()}
 
 
-def _parse_server_from_toml(raw: dict[str, Any]) -> MCPServerConfig:
+def _resolve_path_arg(arg: str, base_dir: Path) -> str:
+    """Prepend base_dir to arg if it looks like a relative file path."""
+    if "/" in arg and not arg.startswith(("/", "-", "@", "$")):
+        return str(base_dir / arg)
+    return arg
+
+
+def _parse_server_from_toml(raw: dict[str, Any], base_dir: Path) -> MCPServerConfig:
     """Parse a single [[mcp.servers]] TOML entry."""
     transport = MCPTransport(raw.get("transport", "stdio"))
     env = _interpolate_dict(raw.get("env", {}))
@@ -183,7 +190,7 @@ def _parse_server_from_toml(raw: dict[str, Any]) -> MCPServerConfig:
         transport=transport,
         enabled=raw.get("enabled", True),
         command=raw.get("command"),
-        args=raw.get("args", []),
+        args=[_resolve_path_arg(a, base_dir) for a in raw.get("args", [])],
         env=env,
         url=raw.get("url"),
         headers=headers,
@@ -233,9 +240,9 @@ def _merge_mcp_raw(base: dict[str, Any], override: dict[str, Any]) -> dict[str, 
     return merged
 
 
-def _parse_mcp_config(mcp_raw: dict[str, Any]) -> MCPConfig:
+def _parse_mcp_config(mcp_raw: dict[str, Any], base_dir: Path) -> MCPConfig:
     """Parse a raw [mcp] section dict into an MCPConfig."""
-    servers = [_parse_server_from_toml(s) for s in mcp_raw.get("servers", [])]
+    servers = [_parse_server_from_toml(s, base_dir) for s in mcp_raw.get("servers", [])]
     srv_raw = mcp_raw.get("server", {})
     # Parse approval_policy sub-table
     ap_raw = srv_raw.get("approval_policy", {})
@@ -380,7 +387,7 @@ def load_mcp_config(config_dir: Path | None = None) -> MCPConfig:
     if mcp_raw and not mcp_raw.get("enabled", True):
         return MCPConfig(enabled=False)
 
-    toml_cfg = _parse_mcp_config(mcp_raw) if mcp_raw else None
+    toml_cfg = _parse_mcp_config(mcp_raw, base_dir) if mcp_raw else None
 
     # Merge: TOML+local servers + env-defined servers
     toml_servers = toml_cfg.servers if toml_cfg else []

--- a/tests/test_mcp_config.py
+++ b/tests/test_mcp_config.py
@@ -531,3 +531,97 @@ def test_env_server_disabled_flag(tmp_path: Path, monkeypatch: pytest.MonkeyPatc
     cfg = load_mcp_config(tmp_path)
     assert len(cfg.servers) == 1
     assert cfg.servers[0].enabled is False
+
+
+# ── Relative path resolution in args ─────────────────────────────────────────
+
+
+def test_relative_arg_resolved_to_base_dir(tmp_path: Path) -> None:
+    """Relative path in args is resolved against the config directory."""
+    (tmp_path / "pincer.toml").write_text("""
+[mcp]
+[[mcp.servers]]
+name = "memory"
+transport = "stdio"
+command = "python"
+args = ["src/sqlite-vec-memory-mcp/memory_server.py"]
+""")
+    cfg = load_mcp_config(tmp_path)
+    assert cfg.servers[0].args == [str(tmp_path / "src/sqlite-vec-memory-mcp/memory_server.py")]
+
+
+def test_absolute_arg_unchanged(tmp_path: Path) -> None:
+    """Absolute path in args is not modified."""
+    (tmp_path / "pincer.toml").write_text("""
+[mcp]
+[[mcp.servers]]
+name = "node"
+transport = "stdio"
+command = "node"
+args = ["/usr/local/lib/server/index.js"]
+""")
+    cfg = load_mcp_config(tmp_path)
+    assert cfg.servers[0].args == ["/usr/local/lib/server/index.js"]
+
+
+def test_non_path_args_unchanged(tmp_path: Path) -> None:
+    """Flags, npm scopes, and env-var refs in args are not modified."""
+    (tmp_path / "pincer.toml").write_text("""
+[mcp]
+[[mcp.servers]]
+name = "github"
+transport = "stdio"
+command = "npx"
+args = ["-y", "@modelcontextprotocol/server-github", "${GITHUB_TOKEN}"]
+""")
+    cfg = load_mcp_config(tmp_path)
+    assert cfg.servers[0].args == ["-y", "@modelcontextprotocol/server-github", "${GITHUB_TOKEN}"]
+
+
+def test_relative_arg_in_local_toml_resolved(tmp_path: Path) -> None:
+    """Relative path in pincer.local.toml args is resolved against the same base_dir."""
+    (tmp_path / "pincer.local.toml").write_text("""
+[mcp]
+[[mcp.servers]]
+name = "pomodoro"
+transport = "stdio"
+command = "python"
+args = ["src/pomodoro-mcp/pomodoro_server.py"]
+""")
+    cfg = load_mcp_config(tmp_path)
+    assert cfg.servers[0].args == [str(tmp_path / "src/pomodoro-mcp/pomodoro_server.py")]
+
+
+def test_pincer_toml_relative_paths_load_without_error(tmp_path: Path) -> None:
+    """The corrected pincer.toml layout (relative paths, fixed filenames) loads cleanly."""
+    (tmp_path / "pincer.toml").write_text("""
+[mcp]
+enabled = true
+
+[[mcp.servers]]
+name = "memory"
+transport = "stdio"
+command = "python"
+args = ["src/sqlite-vec-memory-mcp/memory_server.py"]
+
+[[mcp.servers]]
+name = "pomodoro"
+transport = "stdio"
+command = "python"
+args = ["src/pomodoro-mcp/pomodoro_server.py"]
+
+[[mcp.servers]]
+name = "newsapi"
+transport = "stdio"
+command = "python"
+args = ["src/pincer-mcps/newsapi_server.py"]
+""")
+    cfg = load_mcp_config(tmp_path)
+    assert cfg.enabled is True
+    assert len(cfg.servers) == 3
+    names = {s.name for s in cfg.servers}
+    assert names == {"memory", "pomodoro", "newsapi"}
+    memory = next(s for s in cfg.servers if s.name == "memory")
+    assert memory.args == [str(tmp_path / "src/sqlite-vec-memory-mcp/memory_server.py")]
+    pomodoro = next(s for s in cfg.servers if s.name == "pomodoro")
+    assert pomodoro.args == [str(tmp_path / "src/pomodoro-mcp/pomodoro_server.py")]


### PR DESCRIPTION
## What

Resolve relative file paths in MCP server `args` against the directory where `pincer.toml` lives (`base_dir`). Fix two wrong filenames in `pincer.toml` (`server.py` → `memory_server.py`, `server.py` → `pomodoro_server.py`).

## Why

All seven MCP servers fail to start when running Pincer locally because `pincer.toml` ships with hardcoded `/app/src/...` Docker paths. Two servers are additionally broken by wrong script filenames. Fixes #107.

## How

`load_mcp_config` already computes `base_dir = config_dir or Path.cwd()` (the directory containing `pincer.toml`). A new helper `_resolve_path_arg(arg, base_dir)` prepends `base_dir` to any arg that looks like a relative path — one that contains `/` and doesn't start with `/`, `-`, `@`, or `$`. This keeps flags, npm scopes, absolute paths, and `${VAR}` refs untouched.

`base_dir` is threaded through `_parse_mcp_config` → `_parse_server_from_toml` and applied to the `args` list at parse time. `pincer.toml` is updated to use relative paths so the resolution kicks in correctly in both Docker (`/app` as base) and local environments (repo root as base).

This is complementary to PR #109 (`${VAR}` interpolation in args) — the two mechanisms are orthogonal and can coexist.

## Testing

- [x] Unit tests added/updated — 5 new tests in `tests/test_mcp_config.py` covering: relative path resolved, absolute path unchanged, flags/npm-scopes/`${VAR}` unchanged, `pincer.local.toml` relative paths also resolved, full corrected layout loads cleanly
- [x] Manual testing done
- [x] `pincer doctor` passes

```
Pincer Security Doctor  Score: 63/100
  19 passed  7 warnings  4 critical

MCP section — all green:
✅ mcp_config_valid      MCP config valid — 7 enabled server(s)
✅ mcp_sandbox_enabled   All stdio MCP servers are sandboxed
✅ mcp_approval_not_byp… No MCP servers bypass approval
✅ mcp_no_plaintext_sec… No plaintext secrets in pincer.toml
✅ mcp_tool_count        7 MCP server(s) configured
✅ mcp_collisions        Tool name collision risk is low
✅ mcp_servers           All stdio MCP server commands found
✅ mcp_injection_alerts  Prompt injection detection is active

Warnings and criticals are pre-existing env/filesystem setup issues
unrelated to this change.
```

## Checklist

- [x] Code follows project conventions
- [x] Self-review completed
- [x] Documentation updated (if applicable)
- [x] No sensitive data (API keys, tokens) in code
- [ ] Changelog updated (for user-facing changes)