### PR TITLE
fix(mcp): MCP servers still broken locally after #109 — fix hardcoded paths and wrong filenames

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -37,6 +37,7 @@ PINCER_SUMMARY_THRESHOLD=20
 
 # ── Storage & Logging ────────────────────────
 # PINCER_DATA_DIR=~/.pincer             # Default
+# PINCER_SRC_DIR=                       # Repo root for MCP server paths. Defaults to $PWD (set if running pincer outside the project root). Docker default: /app via WORKDIR.
 PINCER_LOG_LEVEL=INFO
 
 # ═══════════════════════════════════════════════

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,6 @@ x-pincer-base: &pincer-base
   build:
     context: .
     target: runtime
-  working_dir: /app/data
   env_file:
     - path: .env
       required: false

--- a/pincer.toml
+++ b/pincer.toml
@@ -124,44 +124,44 @@ expose_tools = [
 name = "memory"
 transport = "stdio"
 command = "python"
-args = ["/app/src/sqlite-vec-memory-mcp/server.py"]
-env = { MEMORY_DB_PATH = "/app/data/sqlite_vec.db" }
+args = ["${PINCER_SRC_DIR:-$PWD}/src/sqlite-vec-memory-mcp/memory_server.py"]
+env = { MEMORY_DB_PATH = "${PINCER_DATA_DIR}/sqlite_vec.db" }
 sandbox = true
 
 [[mcp.servers]]
 name      = "newsapi"
 transport = "stdio"
 command = "python"
-args = ["/app/src/pincer-mcps/newsapi_server.py"]
+args = ["${PINCER_SRC_DIR:-$PWD}/src/pincer-mcps/newsapi_server.py"]
 env = { API_KEY="${PINCER_NEWSAPI_KEY}" }
 
 [[mcp.servers]]
 name      = "openweathermap"
 transport = "stdio"
 command = "python"
-args = ["/app/src/pincer-mcps/openweathermap_server.py"]
+args = ["${PINCER_SRC_DIR:-$PWD}/src/pincer-mcps/openweathermap_server.py"]
 env = { API_KEY="${PINCER_OPENWEATHERMAP_API_KEY}" }
 
 [[mcp.servers]]
 name      = "pomodoro"
 transport = "stdio"
 command = "python"
-args = ["/app/src/pomodoro-mcp/server.py"]
+args = ["${PINCER_SRC_DIR:-$PWD}/src/pomodoro-mcp/pomodoro_server.py"]
 
 [[mcp.servers]]
 name      = "stock_price"
 transport = "stdio"
 command = "python"
-args = ["/app/src/pincer-mcps/stock_price_server.py"]
+args = ["${PINCER_SRC_DIR:-$PWD}/src/pincer-mcps/stock_price_server.py"]
 
 [[mcp.servers]]
 name      = "summarize"
 transport = "stdio"
 command = "python"
-args = ["/app/src/pincer-mcps/summarize_server.py"]
+args = ["${PINCER_SRC_DIR:-$PWD}/src/pincer-mcps/summarize_server.py"]
 
 [[mcp.servers]]
 name      = "translate"
 transport = "stdio"
 command = "python"
-args = ["/app/src/pincer-mcps/translate_server.py"]
+args = ["${PINCER_SRC_DIR:-$PWD}/src/pincer-mcps/translate_server.py"]

--- a/src/pincer/mcp/config.py
+++ b/src/pincer/mcp/config.py
@@ -156,13 +156,17 @@ class MCPConfig:
 
 
 def _interpolate_env(value: str) -> str:
-    """Resolve ${VAR} references in config values using os.environ."""
+    """Resolve ${VAR} and ${VAR:-$FALLBACK} references in config values using os.environ."""
 
     def _replace(m: re.Match[str]) -> str:
-        var = m.group(1)
-        return os.environ.get(var, m.group(0))
+        var, fallback_var = m.group(1), m.group(2)
+        if var in os.environ:
+            return os.environ[var]
+        if fallback_var is not None:
+            return os.environ.get(fallback_var, m.group(0))
+        return m.group(0)
 
-    return re.sub(r"\$\{([^}]+)\}", _replace, value)
+    return re.sub(r"\$\{([^}:]+)(?::-\$([^}]+))?\}", _replace, value)
 
 
 def _interpolate_dict(d: dict[str, str]) -> dict[str, str]:

--- a/tests/test_mcp_config.py
+++ b/tests/test_mcp_config.py
@@ -97,7 +97,53 @@ def test_env_interpolation_no_vars() -> None:
     assert result == "plain string"
 
 
+def test_env_interpolation_fallback_primary_wins(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("MY_VAR", "primary")
+    monkeypatch.setenv("MY_FALLBACK", "fallback")
+    result = _interpolate_env("${MY_VAR:-$MY_FALLBACK}/path")
+    assert result == "primary/path"
+
+
+def test_env_interpolation_fallback_used_when_primary_unset(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("MY_VAR", raising=False)
+    monkeypatch.setenv("MY_FALLBACK", "/resolved")
+    result = _interpolate_env("${MY_VAR:-$MY_FALLBACK}/src/server.py")
+    assert result == "/resolved/src/server.py"
+
+
+def test_env_interpolation_fallback_passthrough_when_both_unset(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("MY_VAR", raising=False)
+    monkeypatch.delenv("MY_FALLBACK", raising=False)
+    result = _interpolate_env("${MY_VAR:-$MY_FALLBACK}/src")
+    assert result == "${MY_VAR:-$MY_FALLBACK}/src"
+
+
+def test_env_interpolation_fallback_primary_takes_precedence_over_set_fallback(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("MY_VAR", "/override")
+    monkeypatch.setenv("MY_FALLBACK", "/should-not-appear")
+    result = _interpolate_env("${MY_VAR:-$MY_FALLBACK}")
+    assert result == "/override"
+
+
 # ── TOML loading ─────────────────────────────────────────────────────────────
+
+
+def test_fallback_interpolation_in_toml_args(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("PINCER_SRC_DIR", raising=False)
+    monkeypatch.setenv("PWD", "/home/user/pincer")
+    toml_content = """
+[mcp]
+enabled = true
+
+[[mcp.servers]]
+name = "memory"
+transport = "stdio"
+command = "python"
+args = ["${PINCER_SRC_DIR:-$PWD}/src/sqlite-vec-memory-mcp/memory_server.py"]
+"""
+    (tmp_path / "pincer.toml").write_text(toml_content)
+    cfg = load_mcp_config(tmp_path)
+    assert cfg.servers[0].args[0] == "/home/user/pincer/src/sqlite-vec-memory-mcp/memory_server.py"
 
 
 def test_load_mcp_config_no_file(tmp_path: Path) -> None:


### PR DESCRIPTION
## What

Fix MCP servers failing to connect when running Pincer locally (outside Docker). Despite #109 being merged and issue #107 being closed, the root causes were not addressed: `pincer.toml` still ships with hardcoded `/app/src/...` Docker-only paths, and two servers (`memory`, `pomodoro`) reference wrong filenames on disk.

**Note:** PR #109 added `${VAR}` interpolation support to `args` — the plumbing was correct, but `pincer.toml` itself was never updated to use it, and the filename bugs were not fixed. Issue #107 should be re-opened or tracked as still unresolved until this lands.

## Why

As reported in #107 and per the suggestion from @TamiasSibiricus in the issue comments:

> The problem [is] hardcoded paths inside config. Due different ways of usage run locally through venv and docker there [are] possible different path[s] to mcp server. [...] I propose to implement ENV recognition in args section.

#109 implemented ENV recognition in args, but left `pincer.toml` pointing at `/app/src/...`. Two additional filename bugs also remained:
- `sqlite-vec-memory-mcp/server.py` → actual file: `memory_server.py`
- `pomodoro-mcp/server.py` → actual file: `pomodoro_server.py`

## How

**1. Extended `_interpolate_env` to support `${VAR:-$FALLBACK}` syntax** (shell-style parameter expansion with an env-var fallback, not a literal default). The existing `${VAR}` pass-through behavior is fully preserved.

**2. Updated all seven `[[mcp.servers]]` entries in `pincer.toml`:**
- Replaced `/app/src/` with `${PINCER_SRC_DIR:-$PWD}/src/` — resolves to the repo root via `$PWD` by default when running locally, or `/app` in Docker (see below)
- Fixed `server.py` → `memory_server.py` and `server.py` → `pomodoro_server.py`
- Changed memory `MEMORY_DB_PATH` from hardcoded `/app/data/sqlite_vec.db` to `${PINCER_DATA_DIR}/sqlite_vec.db` (already set correctly in docker-compose)

**3. Removed `working_dir: /app/data` from `docker-compose.yml`** — this override was masking the Dockerfile's `WORKDIR /app`. Without it, `PWD=/app` in the container, so `${PINCER_SRC_DIR:-$PWD}/src/...` resolves to `/app/src/...` correctly with zero config.

**4. Documented `PINCER_SRC_DIR=` in `.env.example`** for power users who run `pincer` from a non-root directory.

**Path resolution summary:**

| Environment | `PINCER_SRC_DIR` set? | `PWD` | Resolves to |
|---|---|---|---|
| Local (run from repo root) | No | `/path/to/pincer` | `/path/to/pincer/src/...` ✅ |
| Local (custom dir) | Yes | any | `$PINCER_SRC_DIR/src/...` ✅ |
| Docker (no `.env`) | No | `/app` (via WORKDIR) | `/app/src/...` ✅ |
| Docker (with `.env`) | Yes | any | `$PINCER_SRC_DIR/src/...` ✅ |

## Testing

- [x] Unit tests added/updated
- [x] Manual testing done
- [x] `pincer doctor` passes (see note below)

**Unit tests — 48/48 passing:**

```
uv run pytest tests/test_mcp_config.py -v

tests/test_mcp_config.py::test_env_interpolation PASSED
tests/test_mcp_config.py::test_env_interpolation_missing_var PASSED
tests/test_mcp_config.py::test_env_interpolation_no_vars PASSED
tests/test_mcp_config.py::test_env_interpolation_fallback_primary_wins PASSED
tests/test_mcp_config.py::test_env_interpolation_fallback_used_when_primary_unset PASSED
tests/test_mcp_config.py::test_env_interpolation_fallback_passthrough_when_both_unset PASSED
tests/test_mcp_config.py::test_env_interpolation_fallback_primary_takes_precedence_over_set_fallback PASSED
tests/test_mcp_config.py::test_fallback_interpolation_in_toml_args PASSED
... (40 more existing tests) ...
48 passed in 0.08s
```

**`pincer doctor` — Score: 70/100 (same as before, no regressions):**

```
Pincer Security Doctor  Score: 70/100

 Check                         Message                         Fix
 MCP
 ✅  mcp_config_valid           MCP config valid — 7 enabled server(s)
 ✅  mcp_servers                All stdio MCP server commands found
 ✅  mcp_no_plaintext_secrets   No plaintext secrets in pincer.toml
 ✅  mcp_tool_count             7 MCP server(s) configured
 ✅  mcp_collisions             Tool name collision risk is low
 ✅  mcp_injection_alerts       Prompt injection detection is active
 ⚠️  mcp_env_vars               Unresolved env var(s): DATABASE_URL,
                                GITHUB_TOKEN, PINCER_DATA_DIR,
                                PINCER_NEWSAPI_KEY,
                                PINCER_OPENWEATHERMAP_API_KEY,
                                PINCER_SRC_DIR:-$PWD

  21 passed  6 warnings  3 critical
```

> Note: `mcp_env_vars` warns about `PINCER_SRC_DIR:-$PWD` because the doctor's env-var scanner matches `${...}` patterns literally and doesn't evaluate fallback syntax — this is a cosmetic false-positive in the doctor check, not a runtime issue. At runtime, `_interpolate_env` correctly resolves `${PINCER_SRC_DIR:-$PWD}` to `$PWD` when `PINCER_SRC_DIR` is unset.

## Checklist

- [x] Code follows project conventions
- [x] Self-review completed
- [x] Documentation updated (`PINCER_SRC_DIR` in `.env.example`)
- [x] No sensitive data (API keys, tokens) in code
- [ ] Changelog updated (for user-facing changes)