### PR TITLE
feat: multi-provider LLM router with random failover and per-provider models

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,18 +5,54 @@
 #   cp .env.example .env
 
 # ── LLM Provider ─────────────────────────────
-PINCER_DEFAULT_PROVIDER=anthropic       # anthropic | openai | grok | ollama
-PINCER_ANTHROPIC_API_KEY=sk-ant-...     # Required for Anthropic
-PINCER_OPENAI_API_KEY=sk-proj-...       # Required for OpenAI + voice transcription
-PINCER_GROK_API_KEY=                    # Required for xAI Grok
-PINCER_DEFAULT_MODEL=claude-sonnet-4-5-20250929
+# Well-known providers ("openai"/"anthropic") need only an API key — the base URL
+# is built in. Any other provider name (grok, ollama, a proxy, …) is a "compatible"
+# endpoint: name it via *_COMPATIBLE_PROVIDER and point it at a base URL below.
+PINCER_DEFAULT_PROVIDER=anthropic       # "openai" | "anthropic" | or a *_COMPATIBLE_PROVIDER
+PINCER_FALLBACK_PROVIDERS=              # Up to 3 comma-separated provider names for random failover
+PINCER_ANTHROPIC_API_KEY=sk-ant-...     # Required for the well-known "anthropic" provider
+PINCER_OPENAI_API_KEY=sk-proj-...       # Required for the well-known "openai" provider (+ voice transcription)
+PINCER_DEFAULT_MODEL=claude-sonnet-4-5-20250929   # Model for the PRIMARY provider
 PINCER_MAX_TOKENS=4096
 PINCER_TEMPERATURE=0.7
+# Each provider has its OWN model so failover targets the right one (empty → default_model):
+PINCER_ANTHROPIC_MODEL=                 # model when "anthropic" is primary/failover
+PINCER_OPENAI_MODEL=                    # model when "openai" is primary/failover (e.g. gpt-4o)
 
-# ── Ollama (local, no API key needed) ────────
-# PINCER_DEFAULT_PROVIDER=ollama
-# PINCER_DEFAULT_MODEL=llama3.2           # Optional: defaults to llama3.2 via MODEL_MAP; set to any model you have pulled
-# PINCER_OLLAMA_BASE_URL=http://localhost:11434/v1
+# ── Compatible endpoints (Grok, Ollama, local proxies, gateways) ────────────────
+# Give each endpoint a free-form name, then reference it in DEFAULT/FALLBACK above.
+# Key is optional (e.g. Ollama needs none). Set the endpoint's model on its own
+# *_COMPATIBLE_MODEL var (empty → falls back to PINCER_DEFAULT_MODEL).
+#
+# Grok example:
+#   PINCER_DEFAULT_PROVIDER=grok
+#   PINCER_OPENAI_COMPATIBLE_PROVIDER=grok
+#   PINCER_OPENAI_COMPATIBLE_BASE_URL=https://api.x.ai/v1
+#   PINCER_OPENAI_COMPATIBLE_API_KEY=xai-...
+#   PINCER_OPENAI_COMPATIBLE_MODEL=grok-3
+#
+# Ollama example (no key):
+#   PINCER_DEFAULT_PROVIDER=ollama
+#   PINCER_OPENAI_COMPATIBLE_PROVIDER=ollama
+#   PINCER_OPENAI_COMPATIBLE_BASE_URL=http://localhost:11434/v1
+#   PINCER_OPENAI_COMPATIBLE_MODEL=llama3.2
+#
+# Failover example — Anthropic primary, Ollama failover, each with its own model:
+#   PINCER_DEFAULT_PROVIDER=anthropic
+#   PINCER_FALLBACK_PROVIDERS=ollama
+#   PINCER_DEFAULT_MODEL=claude-sonnet-4-5-20250929
+#   PINCER_OPENAI_COMPATIBLE_PROVIDER=ollama
+#   PINCER_OPENAI_COMPATIBLE_BASE_URL=http://localhost:11434/v1
+#   PINCER_OPENAI_COMPATIBLE_MODEL=llama3.2
+PINCER_OPENAI_COMPATIBLE_PROVIDER=
+PINCER_OPENAI_COMPATIBLE_BASE_URL=
+PINCER_OPENAI_COMPATIBLE_API_KEY=
+PINCER_OPENAI_COMPATIBLE_MODEL=
+# Anthropic-wire endpoint (proxy/gateway):
+PINCER_ANTHROPIC_COMPATIBLE_PROVIDER=
+PINCER_ANTHROPIC_COMPATIBLE_BASE_URL=
+PINCER_ANTHROPIC_COMPATIBLE_API_KEY=
+PINCER_ANTHROPIC_COMPATIBLE_MODEL=
 
 # ── Telegram ─────────────────────────────────
 PINCER_TELEGRAM_BOT_TOKEN=              # From @BotFather
@@ -41,7 +77,8 @@ PINCER_MEMORY_ENABLED=true
 PINCER_MEMORY_BACKEND=sqlite
 # PINCER_MEMORY_BACKEND=mcp
 # PINCER_MEMORY_MCP_SERVER=sqlite-vec-memory # Optional: change name regarding mcp servers config. works only if PINCER_MEMORY_BACKEND=mcp
-PINCER_SUMMARY_MODEL=claude-haiku-4-5-20251001  # For Ollama: defaults to llama3.2 automatically; override if needed
+PINCER_SUMMARY_PROVIDER=                        # Which pool provider summarizes (defaults to the primary)
+PINCER_SUMMARY_MODEL=claude-haiku-4-5-20251001  # Model used for summarization on that provider
 PINCER_SUMMARY_THRESHOLD=20
 
 # ── Storage & Logging ────────────────────────

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+#### Multi-provider LLM architecture with random failover
+
+- **`LLMRouter`** — a single construction entry point (`pincer.llm.router`) that also *is* a `BaseLLMProvider`. `cli.py` and `api/_deps.py` now call `LLMRouter().get_llm()` / `.get_summarizer()`; adding a provider touches only `pincer/llm/`.
+- **1 + N failover** — configure a primary plus up to 3 failovers via `PINCER_FALLBACK_PROVIDERS`. On any `LLMError`/`LLMRateLimitError` (after a provider's own retries) the router falls over to a randomly-ordered failover, re-sampled per failure, and re-raises the primary's error if all fail. `stream()` fails over only before the first token. `LLMResponse.model` reflects the provider that actually served the response.
+- **Compatible endpoints** — any OpenAI- or Anthropic-wire endpoint (Grok, Ollama, OpenRouter, LiteLLM, local proxies, gateways) is configured as a named compatible provider: `PINCER_OPENAI_COMPATIBLE_PROVIDER`/`_BASE_URL`/`_API_KEY` and the `PINCER_ANTHROPIC_COMPATIBLE_*` equivalents. A custom OpenAI-wire and a custom Anthropic-wire endpoint can run side by side.
+- **Per-provider models** — each provider carries its own model id (`PINCER_ANTHROPIC_MODEL`, `PINCER_OPENAI_MODEL`, `PINCER_OPENAI_COMPATIBLE_MODEL`, `PINCER_ANTHROPIC_COMPATIBLE_MODEL`), each defaulting to `PINCER_DEFAULT_MODEL` when unset. This makes failover correct: e.g. an `anthropic` primary on `claude-sonnet-4-5` can fall over to an Ollama endpoint on `llama3.2` instead of sending the Claude model id to Ollama.
+- **Cost attributed to the serving provider** — `LLMResponse.provider` carries the provider that actually served the response (the failover, when one is used), and cost/`is_free` are recorded against it rather than the configured primary. Fixes mis-billing on the failover path.
+- **Fail-fast provider validation** — building the provider pool raises a clear error instead of a runtime 401/404 when a well-known `openai`/`anthropic` provider is missing its API key, or when an OpenAI-wire provider resolves to a `claude-*` model (the Anthropic default leaking onto a non-Anthropic endpoint — set that provider's `*_MODEL`).
+- **Configurable Summarizer provider** — `PINCER_SUMMARY_PROVIDER` selects which pool provider summarizes (defaults to the primary).
+- **Free-provider cost handling** — keyless endpoints (e.g. local Ollama) are billed at `$0` via `LLMRouter.is_free()`, replacing the hardcoded provider allowlist.
+
+### Changed
+
+- **Provider names are now free-form.** `openai`/`anthropic` are well-known (key only, built-in base URL); any other `PINCER_DEFAULT_PROVIDER` value must match a configured `*_COMPATIBLE_PROVIDER`.
+- Provider classes renamed/generalised: `AnthropicProvider` → `AnthropicCompatibleProvider` (`llm/anthropic_common.py`), `_openai_common.py` → `llm/openai_common.py`. Both select well-known vs compatible config from the provider name.
+
+### Removed
+
+- **`grok`/`ollama` as named providers**, their dedicated env vars (`PINCER_GROK_*`, `PINCER_OLLAMA_BASE_URL`), and the claude→model maps. **Migration:** point them at a compatible endpoint instead, e.g. `PINCER_DEFAULT_PROVIDER=grok` + `PINCER_OPENAI_COMPATIBLE_PROVIDER=grok` + `PINCER_OPENAI_COMPATIBLE_BASE_URL=https://api.x.ai/v1` + `PINCER_DEFAULT_MODEL=grok-3` (Ollama: base URL `http://localhost:11434/v1`, model `llama3.2`, no key).
+- Empty provider stub modules (`deep_seek_provider.py`, `google_gemini_provider.py`, `groq_provider.py`, `mistral_provider.py`).
+
 #### Cross-channel identity overhaul
 
 - **N-channel identity format** — `PINCER_IDENTITY_MAP` now supports any number of channels per identity: `john@telegram:johnDoe=whatsapp:491234567890=signal:491234567890`. Old two-channel format (`telegram:12345=whatsapp:491234567890`) is fully backward-compatible.

--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ So I built it. Pincer is the agent I wanted. If you want the same thing, it's yo
 
 ### Prerequisites
 
-You need three things: **Python 3.12+**, **an LLM API key** (Anthropic, OpenAI, Grok, or free with Ollama), and **a Telegram bot token** (takes 2 min via [@BotFather](https://t.me/BotFather)).
+You need three things: **Python 3.12+**, **an LLM API key** (Anthropic or OpenAI out of the box; Grok, Ollama, and any OpenAI-/Anthropic-compatible endpoint also supported), and **a Telegram bot token** (takes 2 min via [@BotFather](https://t.me/BotFather)).
 
 ### Option 1: pip
 
@@ -138,7 +138,7 @@ docker compose up -d         # dashboard on localhost:8080
 ### Minimal .env
 
 ```bash
-PINCER_ANTHROPIC_API_KEY=sk-ant-...    # Anthropic, OpenAI, or Grok
+PINCER_ANTHROPIC_API_KEY=sk-ant-...    # well-known: anthropic or openai (compatible endpoints use *_COMPATIBLE_*)
 PINCER_TELEGRAM_BOT_TOKEN=7000000:AAx... # From @BotFather
 PINCER_TELEGRAM_ALLOWED_USERS=123456789  # Your Telegram user ID
 PINCER_DAILY_BUDGET_USD=5.00           # Hard daily spending limit in USD
@@ -440,16 +440,68 @@ These are focus decisions, not limitations. Every feature we didn't build is mai
 <details>
 <summary><strong>🤖 Supported Models</strong></summary>
 
-Set one or more — failover is automatic.
+Configure a primary provider and up to 3 failovers (`PINCER_FALLBACK_PROVIDERS`) — on an error the primary falls over to a randomly-chosen failover.
+
+**Two well-known providers** need only an API key (base URL is built in):
 
 | Provider | Env var | Models |
 |----------|---------|--------|
 | **Anthropic** ⭐ | `PINCER_ANTHROPIC_API_KEY` | Claude Opus 4.6 / Sonnet 4.5 / Haiku 4.5 |
 | **OpenAI** | `PINCER_OPENAI_API_KEY` | GPT-4o / GPT-5 / o-series |
-| **xAI Grok** | `PINCER_GROK_API_KEY` | Grok-2 / Grok-3 (OpenAI-compatible API) |
-| **DeepSeek** | `PINCER_LLM_API_KEY` | DeepSeek V3 / R1 |
-| **Ollama** | `OLLAMA_HOST` | Any local model — fully offline, $0 |
-| **OpenRouter** | `PINCER_LLM_API_KEY` | 100+ models, single key |
+
+**Everything else** (Grok, Ollama, OpenRouter, DeepSeek, LiteLLM, local proxies, gateways) is a *compatible endpoint* — anything speaking the OpenAI or Anthropic wire format. Name it, point it at a base URL, set its model.
+
+**Each provider carries its own model**, so failover always targets a model that endpoint actually has (`*_MODEL` / `*_COMPATIBLE_MODEL`; empty → `PINCER_DEFAULT_MODEL`).
+
+#### Fast config (one provider, the common case)
+
+```bash
+PINCER_DEFAULT_PROVIDER=anthropic
+PINCER_ANTHROPIC_API_KEY=sk-ant-...
+PINCER_DEFAULT_MODEL=claude-sonnet-4-5-20250929
+```
+
+Single compatible endpoint, e.g. Grok or fully-offline Ollama:
+
+```bash
+# Grok (OpenAI-compatible wire)
+PINCER_DEFAULT_PROVIDER=grok
+PINCER_OPENAI_COMPATIBLE_PROVIDER=grok
+PINCER_OPENAI_COMPATIBLE_BASE_URL=https://api.x.ai/v1
+PINCER_OPENAI_COMPATIBLE_API_KEY=xai-...
+PINCER_OPENAI_COMPATIBLE_MODEL=grok-3
+
+# Ollama (OpenAI-compatible wire, no key — $0)
+PINCER_DEFAULT_PROVIDER=ollama
+PINCER_OPENAI_COMPATIBLE_PROVIDER=ollama
+PINCER_OPENAI_COMPATIBLE_BASE_URL=http://localhost:11434/v1
+PINCER_OPENAI_COMPATIBLE_MODEL=llama3.2
+```
+
+#### Extended config (up to 4 providers, each its own model)
+
+One primary + three failovers; the router falls over in random order, each using its own model:
+
+```bash
+PINCER_DEFAULT_PROVIDER=anthropic
+PINCER_FALLBACK_PROVIDERS=openai,grok,my-claude
+PINCER_DEFAULT_MODEL=claude-sonnet-4-5-20250929      # primary (anthropic)
+# well-known OpenAI failover
+PINCER_OPENAI_API_KEY=sk-...
+PINCER_OPENAI_MODEL=gpt-4o
+# OpenAI-wire compatible failover (Grok)
+PINCER_OPENAI_COMPATIBLE_PROVIDER=grok
+PINCER_OPENAI_COMPATIBLE_BASE_URL=https://api.x.ai/v1
+PINCER_OPENAI_COMPATIBLE_API_KEY=xai-...
+PINCER_OPENAI_COMPATIBLE_MODEL=grok-3
+# Anthropic-wire compatible failover (proxy/gateway)
+PINCER_ANTHROPIC_COMPATIBLE_PROVIDER=my-claude
+PINCER_ANTHROPIC_COMPATIBLE_BASE_URL=https://your-proxy/v1
+PINCER_ANTHROPIC_COMPATIBLE_API_KEY=...
+PINCER_ANTHROPIC_COMPATIBLE_MODEL=claude-3-7-sonnet
+```
+
+One OpenAI-wire + one Anthropic-wire compatible endpoint can run side by side (one `*_COMPATIBLE_*` set each), so the maximum distinct pool is `anthropic` + `openai` + one OpenAI-compatible + one Anthropic-compatible.
 
 **Recommendation:** Claude Sonnet 4.5 for tool-use quality and prompt-injection resistance. Ollama for zero-cost, fully private operation.
 
@@ -538,7 +590,7 @@ No frameworks. No abstractions. `async/await` + the Anthropic SDK.
 pincer/
 ├── src/pincer/
 │   ├── core/         agent.py, session.py, config.py, soul.py, identity.py
-│   ├── llm/          anthropic, openai, grok, ollama, router, cost_tracker
+│   ├── llm/          anthropic_common, openai_common, router (failover), cost_tracker
 │   ├── channels/     telegram, whatsapp, discord, slack, email, voice, signal, web
 │   ├── memory/       store (SQLite+FTS5), embeddings, entities, summarizer
 │   ├── tools/        registry, sandbox, approval, builtin/ (24 core tools)

--- a/docs/contributing/bug-report.md
+++ b/docs/contributing/bug-report.md
@@ -29,7 +29,7 @@ What actually happened.
 - **Pincer version:** `pincer --version`
 - **Python version:** `python --version`
 - **OS:** (e.g., Ubuntu 24.04, macOS 15, Docker)
-- **LLM provider:** (Anthropic / OpenAI / Ollama)
+- **LLM provider:** (anthropic / openai / compatible endpoint name, e.g. grok/ollama)
 - **Channel:** (Telegram / WhatsApp / Discord)
 
 ## Logs

--- a/docs/contributing/contributing.md
+++ b/docs/contributing/contributing.md
@@ -70,7 +70,7 @@ For a complete development guide including dashboard setup, debugging the agent 
 - [uv](https://github.com/astral-sh/uv) (strongly recommended) or pip
 - Git
 - A Telegram bot token (fastest channel to test against)
-- At least one LLM API key (Anthropic, OpenAI, or free with Ollama)
+- At least one LLM provider (Anthropic/OpenAI key, or a compatible endpoint such as a free local Ollama)
 
 ### Getting Running
 
@@ -101,7 +101,7 @@ If you get stuck at any step, that's a documentation bug. [Open an issue](https:
 pincer/
 ├── src/pincer/
 │   ├── core/           # Agent loop, sessions, events — the brain
-│   ├── llm/            # LLM providers (Anthropic, OpenAI, Ollama, etc.)
+│   ├── llm/            # LLM providers (OpenAI-/Anthropic-wire) + router/failover
 │   ├── channels/       # Telegram, WhatsApp, Discord — the ears and mouth
 │   ├── memory/         # SQLite + FTS5, entities — the memory
 │   ├── tools/          # Tool registry, sandbox — the hands

--- a/docs/core-components/cli.md
+++ b/docs/core-components/cli.md
@@ -711,9 +711,21 @@ All variables use `PINCER_` prefix.
 ### LLM
 | Variable | Default | Description |
 |----------|---------|-------------|
-| `PINCER_DEFAULT_PROVIDER` | `anthropic` | LLM provider |
-| `PINCER_DEFAULT_MODEL` | `claude-3-5-sonnet-20241022` | Model name |
-| `PINCER_OPENAI_API_KEY` | | OpenAI API key |
+| `PINCER_DEFAULT_PROVIDER` | `anthropic` | Primary provider name (`openai`/`anthropic` or a `*_COMPATIBLE_PROVIDER`) |
+| `PINCER_FALLBACK_PROVIDERS` | | Up to 3 comma-separated provider names; random failover on error |
+| `PINCER_DEFAULT_MODEL` | `claude-sonnet-4-5-20250929` | Model for the primary; fallback for any provider without its own `*_MODEL` |
+| `PINCER_ANTHROPIC_MODEL` | | Model for the well-known `anthropic` provider |
+| `PINCER_OPENAI_API_KEY` | | OpenAI API key (well-known `openai`) |
+| `PINCER_OPENAI_MODEL` | | Model for the well-known `openai` provider (e.g. `gpt-4o`) |
+| `PINCER_OPENAI_COMPATIBLE_PROVIDER` | | Name for an OpenAI-wire endpoint (e.g. `grok`, `ollama`) |
+| `PINCER_OPENAI_COMPATIBLE_BASE_URL` | | Base URL for that endpoint |
+| `PINCER_OPENAI_COMPATIBLE_API_KEY` | | Optional key for that endpoint |
+| `PINCER_OPENAI_COMPATIBLE_MODEL` | | Model for that endpoint (e.g. `grok-3`, `llama3.2`) |
+| `PINCER_ANTHROPIC_COMPATIBLE_PROVIDER` | | Name for an Anthropic-wire endpoint |
+| `PINCER_ANTHROPIC_COMPATIBLE_BASE_URL` | | Base URL for that endpoint |
+| `PINCER_ANTHROPIC_COMPATIBLE_API_KEY` | | Optional key for that endpoint |
+| `PINCER_ANTHROPIC_COMPATIBLE_MODEL` | | Model for that endpoint |
+| `PINCER_SUMMARY_PROVIDER` | primary | Pool provider used by the Summarizer |
 
 ### Channels
 | Variable | Default | Description |

--- a/docs/getting-started/development.md
+++ b/docs/getting-started/development.md
@@ -53,7 +53,7 @@ pip install -e ".[dev,all]"
 
 ```bash
 cp .env.example .env
-# Edit .env with your API keys (Anthropic, OpenAI, or Ollama)
+# Edit .env with your API keys (Anthropic/OpenAI, or a compatible endpoint like Ollama)
 ```
 
 Minimal `.env` for development:

--- a/docs/getting-started/project-structure.md
+++ b/docs/getting-started/project-structure.md
@@ -271,9 +271,9 @@ pincer/
 │   │
 │   ├── llm/                        # LLM provider abstraction
 │   │   ├── base.py                 # Abstract BaseLLMProvider + message types
-│   │   ├── anthropic_provider.py   # Anthropic Claude (with message validation)
-│   │   ├── openai_provider.py      # OpenAI GPT implementation
-│   │   ├── ollama_provider.py      # Ollama local models (stub)
+│   │   ├── anthropic_common.py     # Anthropic-wire provider (well-known + compatible)
+│   │   ├── openai_common.py        # OpenAI-wire provider (well-known + compatible)
+│   │   ├── router.py               # LLMRouter — construction + random failover entry point
 │   │   └── cost_tracker.py         # Per-model cost tracking & budget limits
 │   │
 │   ├── memory/                     # Persistent memory system
@@ -378,8 +378,9 @@ pincer/
 | `channels/whatsapp.py` | WhatsApp via neonize — QR pairing, self-chat (LID-aware), DM allowlist, groups, voice/image/docs |
 | `channels/router.py` | Cross-channel message router for proactive delivery |
 | `llm/base.py` | Abstract LLM interface, unified message types |
-| `llm/anthropic_provider.py` | Anthropic Claude — complete + stream with tool use, message validation |
-| `llm/openai_provider.py` | OpenAI GPT — complete + stream with tool use |
+| `llm/anthropic_common.py` | Anthropic-wire provider — complete + stream with tool use, message validation |
+| `llm/openai_common.py` | OpenAI-wire provider — complete + stream with tool use |
+| `llm/router.py` | LLMRouter — single construction entry point + random 1+N failover |
 | `llm/cost_tracker.py` | Per-model token cost tracking with daily budget limits |
 | `memory/store.py` | SQLite memory store with FTS5 full-text search |
 | `memory/summarizer.py` | Conversation summarization with pair-safe splitting |
@@ -406,7 +407,6 @@ pincer/
 |--------|-------------|
 | `channels/discord_channel.py` | Discord bot integration |
 | `channels/web.py` | Web/HTTP REST channel |
-| `llm/ollama_provider.py` | Ollama local model provider |
 
 ---
 
@@ -477,9 +477,15 @@ All configuration via environment variables with `PINCER_` prefix. See `.env.exa
 
 | Variable | Purpose |
 |----------|---------|
-| `PINCER_ANTHROPIC_API_KEY` | Anthropic Claude API key |
-| `PINCER_OPENAI_API_KEY` | OpenAI API key (also used for voice transcription) |
+| `PINCER_ANTHROPIC_API_KEY` | Anthropic Claude API key (well-known `anthropic`) |
+| `PINCER_OPENAI_API_KEY` | OpenAI API key (well-known `openai`; also used for voice transcription) |
 | `PINCER_TELEGRAM_BOT_TOKEN` | Telegram bot token (from @BotFather) |
+
+For Grok, Ollama, or any other endpoint, configure a *compatible* provider instead:
+`PINCER_OPENAI_COMPATIBLE_PROVIDER` / `PINCER_OPENAI_COMPATIBLE_BASE_URL` (+ optional
+`_API_KEY`), or the `PINCER_ANTHROPIC_COMPATIBLE_*` equivalents, then set
+`PINCER_DEFAULT_PROVIDER` to that name. `PINCER_FALLBACK_PROVIDERS` (≤3, comma-separated)
+enables random failover.
 
 ### Optional — WhatsApp
 

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -8,7 +8,7 @@ Get a personal AI agent running on your machine, answering you on Telegram, in u
 
 - **Python 3.12+** — [install](https://python.org/downloads)
 - **A Telegram account** — you'll create a bot via BotFather
-- **An LLM API key** — Anthropic (Claude) recommended, OpenAI and Grok also supported; or run **Ollama locally** (no API key needed)
+- **An LLM API key** — Anthropic (Claude) recommended; OpenAI works out of the box too. Grok, **Ollama** (local, no key), and any OpenAI-/Anthropic-compatible endpoint are supported as *compatible* providers (set a base URL)
 
 ---
 
@@ -41,7 +41,7 @@ pincer init
 
 The wizard walks you through:
 
-1. **LLM Provider** — paste your Anthropic, OpenAI, or Grok API key; or choose Ollama for local models (no key needed)
+1. **LLM Provider** — paste your Anthropic or OpenAI API key, or choose `compatible` to point at a Grok/Ollama/proxy endpoint (base URL + optional key)
 2. **Telegram Bot** — open [@BotFather](https://t.me/BotFather) in Telegram, send `/newbot`, follow prompts, paste the token
 3. **Allowed Users** — enter your Telegram user ID (the wizard shows you how to find it)
 4. **Budget** — set a daily spending limit (default: $5/day)

--- a/src/pincer/api/_deps.py
+++ b/src/pincer/api/_deps.py
@@ -16,7 +16,6 @@ no skills, no rate limiter — those stay in the CLI.
 from __future__ import annotations
 
 import logging
-from typing import TYPE_CHECKING
 
 from pincer.api.approvals import request_web_approval
 from pincer.core.agent import Agent
@@ -25,26 +24,12 @@ from pincer.llm.cost_tracker import CostTracker
 from pincer.tools.bootstrap import register_default_tools
 from pincer.tools.registry import ToolRegistry
 
-if TYPE_CHECKING:
-    from pincer.config import Settings
-    from pincer.llm.base import BaseLLMProvider
-
 logger = logging.getLogger(__name__)
-
-
-def _build_llm(settings: Settings) -> BaseLLMProvider:
-    provider = settings.default_provider.value
-    if provider == "anthropic":
-        from pincer.llm.anthropic_provider import AnthropicProvider
-
-        return AnthropicProvider(settings)
-    from pincer.llm._openai_common import OpenAICompatibleProvider
-
-    return OpenAICompatibleProvider(settings)
 
 
 async def build_agent_from_settings() -> Agent:
     from pincer.config import get_settings_relaxed
+    from pincer.llm.router import LLMRouter
 
     settings = get_settings_relaxed()
 
@@ -54,7 +39,7 @@ async def build_agent_from_settings() -> Agent:
     cost_tracker = CostTracker(settings.db_path, settings.daily_budget_usd)
     await cost_tracker.initialize()
 
-    llm = _build_llm(settings)
+    llm = LLMRouter().get_llm()
 
     tools = ToolRegistry()
     report = register_default_tools(tools, settings)

--- a/src/pincer/cli.py
+++ b/src/pincer/cli.py
@@ -116,7 +116,7 @@ def run() -> None:
             console.print(f"[yellow]Telemetry init failed (non-fatal): {_tel_err}[/yellow]")
 
     console.print(f"[bold green]{settings.agent_name} starting...[/bold green]")
-    console.print(f"   Provider: {settings.default_provider.value}")
+    console.print(f"   Provider: {settings.default_provider}")
     console.print(f"   Model: {settings.default_model}")
     console.print(f"   Budget: ${settings.daily_budget_usd:.2f}/day")
     console.print(f"   Data: {settings.data_dir}")
@@ -172,21 +172,17 @@ async def _run_agent(settings: Settings) -> None:
     memory_store: BaseMemoryBackend | None = None
     summarizer: Summarizer | None = None
 
-    # Create LLM provider
-    if settings.default_provider.value == "anthropic":
-        from pincer.llm.anthropic_provider import AnthropicProvider
+    # Create LLM provider (primary + optional random failover)
+    from pincer.llm.router import LLMRouter
 
-        llm = AnthropicProvider(settings)
-    else:
-        from pincer.llm._openai_common import OpenAICompatibleProvider
-
-        llm = OpenAICompatibleProvider(settings)
+    llm_router = LLMRouter()
+    llm = llm_router.get_llm()
 
     if settings.memory_enabled:
         memory_store = _create_memory_backend(settings)
         await memory_store.initialize()
         summarizer = Summarizer(
-            llm=llm,
+            llm=llm_router.get_summarizer(),
             memory_store=memory_store,
             session_manager=session_mgr,
             summary_model=settings.summary_model,
@@ -1068,7 +1064,7 @@ def config() -> None:
     try:
         settings = get_settings()
         console.print("[bold]Pincer Configuration[/bold]\n")
-        console.print(f"  Provider:     {settings.default_provider.value}")
+        console.print(f"  Provider:     {settings.default_provider}")
         console.print(f"  Model:        {settings.default_model}")
         console.print(f"  Anthropic:    {'set' if settings.anthropic_api_key.get_secret_value() else 'not set'}")
         console.print(f"  OpenAI:       {'set' if settings.openai_api_key.get_secret_value() else 'not set'}")
@@ -1273,7 +1269,7 @@ def init() -> None:
     console.print("\n[bold]Step 1: LLM Provider[/bold]")
     provider = Prompt.ask(
         "Choose provider",
-        choices=["anthropic", "openai", "both"],
+        choices=["anthropic", "openai", "both", "compatible"],
         default="anthropic",
     )
     if provider in ("anthropic", "both"):
@@ -1288,6 +1284,20 @@ def init() -> None:
         if provider == "openai":
             env_lines.append("PINCER_DEFAULT_PROVIDER=openai")
             env_lines.append("PINCER_DEFAULT_MODEL=gpt-4o")
+    if provider == "compatible":
+        # Any OpenAI-/Anthropic-wire endpoint (Grok, Ollama, local proxy, gateway).
+        wire = Prompt.ask("Wire format", choices=["openai", "anthropic"], default="openai")
+        name = Prompt.ask("Provider name (e.g. grok, ollama, my-claude)")
+        base_url = Prompt.ask("Base URL")
+        key = Prompt.ask("API key (empty if not required)", password=True, default="")
+        model = Prompt.ask("Model id (e.g. grok-3, llama3.2)")
+        prefix = "OPENAI" if wire == "openai" else "ANTHROPIC"
+        env_lines.append(f"PINCER_DEFAULT_PROVIDER={name}")
+        env_lines.append(f"PINCER_{prefix}_COMPATIBLE_PROVIDER={name}")
+        env_lines.append(f"PINCER_{prefix}_COMPATIBLE_BASE_URL={base_url}")
+        if key:
+            env_lines.append(f"PINCER_{prefix}_COMPATIBLE_API_KEY={key}")
+        env_lines.append(f"PINCER_{prefix}_COMPATIBLE_MODEL={model}")
 
     # Step 2: Channels
     console.print("\n[bold]Step 2: Channels[/bold]")
@@ -1486,14 +1496,10 @@ async def _chat_loop() -> None:
     cost_tracker = CostTracker(settings.db_path, settings.daily_budget_usd)
     await cost_tracker.initialize()
 
-    if settings.default_provider.value == "anthropic":
-        from pincer.llm.anthropic_provider import AnthropicProvider
+    from pincer.llm.router import LLMRouter
 
-        llm = AnthropicProvider(settings)
-    else:
-        from pincer.llm._openai_common import OpenAICompatibleProvider
-
-        llm = OpenAICompatibleProvider(settings)
+    llm_router = LLMRouter()
+    llm = llm_router.get_llm()
 
     memory_store: BaseMemoryBackend | None = None
     summarizer: Summarizer | None = None
@@ -1511,7 +1517,7 @@ async def _chat_loop() -> None:
             memory_store = None
         else:
             summarizer = Summarizer(
-                llm=llm,
+                llm=llm_router.get_summarizer(),
                 memory_store=memory_store,
                 session_manager=session_mgr,
                 summary_model=settings.summary_model,

--- a/src/pincer/config/llm.py
+++ b/src/pincer/config/llm.py
@@ -1,25 +1,77 @@
 from __future__ import annotations
 
 from enum import StrEnum
+from typing import Annotated
 
-from pydantic import BaseModel, Field, SecretStr
+from pydantic import BaseModel, Field, SecretStr, field_validator
+from pydantic_settings import NoDecode
 
 
 class LLMProvider(StrEnum):
+    """The two well-known provider names. Any other name is resolved as a
+    configured OpenAI-/Anthropic-compatible endpoint (see `pincer.llm.router`)."""
+
     ANTHROPIC = "anthropic"
     OPENAI = "openai"
-    GROK = "grok"
-    OLLAMA = "ollama"
 
 
 class LLMSettings(BaseModel):
-    default_provider: LLMProvider = LLMProvider.ANTHROPIC
+    # Provider names are free-form strings. "openai"/"anthropic" are well-known
+    # (key only); any other name must match a configured *_compatible_provider.
+    default_provider: str = Field(default="anthropic", description="Primary LLM provider name")
+    # NoDecode: skip pydantic-settings' JSON decoding of the env value so the
+    # comma-splitting validator below receives the raw string.
+    fallback_providers: Annotated[list[str], NoDecode] = Field(
+        default_factory=list,
+        description="Up to 3 failover provider names (comma-separated)",
+    )
+    summary_provider: str | None = Field(
+        default=None,
+        description="Provider used by the Summarizer; defaults to the primary",
+    )
+
+    # Well-known providers — set the key, base URL is built in.
+    # Each carries an optional model so failover targets the right model id
+    # (empty → falls back to default_model).
     anthropic_api_key: SecretStr = Field(default=SecretStr(""), description="Anthropic API key")
+    anthropic_model: str = Field(
+        default="", description="Model for the 'anthropic' provider (defaults to default_model)"
+    )
     openai_api_key: SecretStr = Field(default=SecretStr(""), description="OpenAI API key")
-    grok_api_key: SecretStr = Field(default=SecretStr(""), description="xAI Grok API key")
     openai_base_url: str = Field(default="https://api.openai.com/v1", description="OpenAI API base URL")
-    grok_base_url: str = Field(default="https://api.x.ai/v1", description="Grok API base URL")
-    ollama_base_url: str = Field(default="http://localhost:11434/v1", description="Ollama API base URL")
+    openai_model: str = Field(default="", description="Model for the 'openai' provider (defaults to default_model)")
+
+    # Compatible endpoints — name each one, set its base URL; key optional; model
+    # falls back to default_model when empty.
+    openai_compatible_provider: str = Field(
+        default="", description="Name for the OpenAI-wire compatible endpoint (e.g. grok, ollama)"
+    )
+    openai_compatible_base_url: str = Field(default="", description="OpenAI-wire compatible endpoint base URL")
+    openai_compatible_api_key: SecretStr = Field(
+        default=SecretStr(""), description="OpenAI-wire compatible endpoint API key (optional)"
+    )
+    openai_compatible_model: str = Field(
+        default="", description="Model for the OpenAI-wire compatible endpoint (defaults to default_model)"
+    )
+    anthropic_compatible_provider: str = Field(
+        default="", description="Name for the Anthropic-wire compatible endpoint"
+    )
+    anthropic_compatible_base_url: str = Field(default="", description="Anthropic-wire compatible endpoint base URL")
+    anthropic_compatible_api_key: SecretStr = Field(
+        default=SecretStr(""), description="Anthropic-wire compatible endpoint API key (optional)"
+    )
+    anthropic_compatible_model: str = Field(
+        default="", description="Model for the Anthropic-wire compatible endpoint (defaults to default_model)"
+    )
+
+    @field_validator("fallback_providers", mode="before")
+    @classmethod
+    def parse_fallback_providers(cls, v: str | list[str]) -> list[str]:
+        if isinstance(v, str):
+            if not v.strip():
+                return []
+            return [name.strip() for name in v.split(",") if name.strip()]
+        return v
 
     default_model: str = Field(
         default="claude-sonnet-4-5-20250929",

--- a/src/pincer/config/main.py
+++ b/src/pincer/config/main.py
@@ -9,7 +9,7 @@ from pydantic_settings import BaseSettings, SettingsConfigDict
 from pincer.config.api import APISettings
 from pincer.config.channels import ChannelSettings
 from pincer.config.core import CoreSettings
-from pincer.config.llm import LLMProvider, LLMSettings
+from pincer.config.llm import LLMSettings
 from pincer.config.mcp import MCPSettings
 from pincer.config.tools import ToolSettings
 
@@ -28,38 +28,21 @@ class Settings(BaseSettings, LLMSettings, ChannelSettings, ToolSettings, APISett
 
     @model_validator(mode="after")
     def validate_api_keys(self) -> Settings:
-        """Ensure at least one LLM provider API key is set."""
-        if self.default_provider == LLMProvider.OLLAMA:
-            return self
-        anthropic_set = self.anthropic_api_key.get_secret_value() != ""
-        openai_set = self.openai_api_key.get_secret_value() != ""
-        grok_set = self.grok_api_key.get_secret_value() != ""
-        if not anthropic_set and not openai_set and not grok_set:
+        """Ensure at least one usable LLM provider is configured.
+
+        Per-leaf validation (which named provider needs which key/base_url) lives
+        in `pincer.llm.router.LLMRouter` at build time so it also covers failovers.
+        """
+        has_anthropic = self.anthropic_api_key.get_secret_value() != ""
+        has_openai = self.openai_api_key.get_secret_value() != ""
+        has_openai_compatible = self.openai_compatible_base_url != ""
+        has_anthropic_compatible = self.anthropic_compatible_base_url != ""
+        if not (has_anthropic or has_openai or has_openai_compatible or has_anthropic_compatible):
             raise ValueError(
-                "At least one LLM API key required. "
-                "Set PINCER_ANTHROPIC_API_KEY, PINCER_OPENAI_API_KEY, or PINCER_GROK_API_KEY."
+                "At least one LLM provider required. Set an API key "
+                "(PINCER_ANTHROPIC_API_KEY / PINCER_OPENAI_API_KEY) or a compatible "
+                "base URL (PINCER_OPENAI_COMPATIBLE_BASE_URL / PINCER_ANTHROPIC_COMPATIBLE_BASE_URL)."
             )
-        if self.default_provider == LLMProvider.ANTHROPIC and not anthropic_set:
-            if openai_set:
-                object.__setattr__(self, "default_provider", LLMProvider.OPENAI)
-            elif grok_set:
-                object.__setattr__(self, "default_provider", LLMProvider.GROK)
-            else:
-                raise ValueError("PINCER_ANTHROPIC_API_KEY required for Anthropic provider.")
-        if self.default_provider == LLMProvider.OPENAI and not openai_set:
-            if anthropic_set:
-                object.__setattr__(self, "default_provider", LLMProvider.ANTHROPIC)
-            elif grok_set:
-                object.__setattr__(self, "default_provider", LLMProvider.GROK)
-            else:
-                raise ValueError("PINCER_OPENAI_API_KEY required for OpenAI provider.")
-        if self.default_provider == LLMProvider.GROK and not grok_set:
-            if anthropic_set:
-                object.__setattr__(self, "default_provider", LLMProvider.ANTHROPIC)
-            elif openai_set:
-                object.__setattr__(self, "default_provider", LLMProvider.OPENAI)
-            else:
-                raise ValueError("PINCER_GROK_API_KEY required for Grok provider.")
         return self
 
     @property

--- a/src/pincer/core/agent.py
+++ b/src/pincer/core/agent.py
@@ -35,6 +35,7 @@ from pincer.llm.base import (
     ToolCall,
     ToolResult,
 )
+from pincer.llm.router import LLMRouter
 from pincer.memory.base import (
     PINCER_MEMORY_ASSISTANT_RESPONSE_PREFIX,
     PINCER_MEMORY_USER_REQUEST_PREFIX,
@@ -429,12 +430,17 @@ class Agent:
 
             # Track cost
             try:
+                # Attribute cost to the provider that actually served (may be a
+                # failover), not the configured primary.
+                provider = response.provider or self._settings.default_provider
+                is_free = self._llm.is_free(provider) if isinstance(self._llm, LLMRouter) else False
                 cost = await self._costs.record(
-                    provider=self._settings.default_provider.value,
+                    provider=provider,
                     model=response.model,
                     input_tokens=response.input_tokens,
                     output_tokens=response.output_tokens,
                     session_id=session.session_id,
+                    is_free=is_free,
                 )
                 total_cost += cost
             except BudgetExceededError as e:

--- a/src/pincer/llm/__init__.py
+++ b/src/pincer/llm/__init__.py
@@ -1,4 +1,4 @@
-from pincer.llm._openai_common import OpenAICompatibleProvider
+from pincer.llm.anthropic_common import AnthropicCompatibleProvider
 from pincer.llm.base import (
     BaseLLMProvider,
     ImageContent,
@@ -8,12 +8,16 @@ from pincer.llm.base import (
     ToolCall,
     ToolResult,
 )
+from pincer.llm.openai_common import OpenAICompatibleProvider
+from pincer.llm.router import LLMRouter
 
 __all__ = [
+    "AnthropicCompatibleProvider",
     "BaseLLMProvider",
     "ImageContent",
     "LLMMessage",
     "LLMResponse",
+    "LLMRouter",
     "MessageRole",
     "OpenAICompatibleProvider",
     "ToolCall",

--- a/src/pincer/llm/anthropic_common.py
+++ b/src/pincer/llm/anthropic_common.py
@@ -36,16 +36,31 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
-class AnthropicProvider(BaseLLMProvider):
-    """Claude LLM provider via Anthropic API."""
+class AnthropicCompatibleProvider(BaseLLMProvider):
+    """Provider for any Anthropic-wire endpoint.
 
-    def __init__(self, settings: Settings) -> None:
+    `provider == "anthropic"` uses the well-known API (key + SDK default
+    endpoint); any other name uses the configured compatible endpoint
+    (base URL + optional key) — local proxies, gateways, etc.
+    """
+
+    def __init__(self, settings: Settings, provider: str) -> None:
         self._settings = settings
-        self._client = AsyncAnthropic(
-            api_key=settings.anthropic_api_key.get_secret_value(),
-            max_retries=2,
-        )
-        self._default_model = settings.default_model
+        self._provider_name = provider
+
+        if provider == "anthropic":
+            api_key = settings.anthropic_api_key.get_secret_value()
+            if not api_key:
+                raise ValueError("provider 'anthropic' needs PINCER_ANTHROPIC_API_KEY")
+            base_url: str | None = None
+            model = settings.anthropic_model or settings.default_model
+        else:
+            api_key = settings.anthropic_compatible_api_key.get_secret_value() or "none"
+            base_url = settings.anthropic_compatible_base_url
+            model = settings.anthropic_compatible_model or settings.default_model
+
+        self._client = AsyncAnthropic(api_key=api_key, base_url=base_url, max_retries=2)
+        self._default_model = model
         self._default_max_tokens = settings.max_tokens
         self._default_temperature = settings.temperature
 
@@ -77,7 +92,9 @@ class AnthropicProvider(BaseLLMProvider):
         except anthropic.APIConnectionError as e:
             raise LLMError(f"Anthropic connection error: {e}") from e
 
-        return self._parse_response(response)
+        result = self._parse_response(response)
+        result.provider = self._provider_name
+        return result
 
     async def stream(
         self,
@@ -123,7 +140,8 @@ class AnthropicProvider(BaseLLMProvider):
         """Call API with exponential backoff on rate limits."""
         for attempt in range(max_retries):
             try:
-                return await self._client.messages.create(**kwargs)
+                result: Message = await self._client.messages.create(**kwargs)
+                return result
             except anthropic.RateLimitError as e:
                 retry_after = float(e.response.headers.get("retry-after", "5"))
                 if attempt == max_retries - 1:

--- a/src/pincer/llm/base.py
+++ b/src/pincer/llm/base.py
@@ -98,6 +98,7 @@ class LLMResponse:
     content: str = ""
     tool_calls: list[ToolCall] = field(default_factory=list)
     model: str = ""
+    provider: str = ""  # name of the provider that actually served this response
     input_tokens: int = 0
     output_tokens: int = 0
     stop_reason: str = ""
@@ -124,7 +125,7 @@ class BaseLLMProvider(ABC):
         ...
 
     @abstractmethod
-    async def stream(
+    def stream(
         self,
         messages: list[LLMMessage],
         tools: list[dict[str, Any]] | None = None,
@@ -133,7 +134,11 @@ class BaseLLMProvider(ABC):
         temperature: float | None = None,
         system: str | None = None,
     ) -> AsyncIterator[str]:
-        """Stream text tokens as they arrive."""
+        """Stream text tokens as they arrive.
+
+        Declared as a plain method returning an async iterator (not ``async def``)
+        so async-generator implementations type-check cleanly as overrides.
+        """
         ...
 
     @abstractmethod

--- a/src/pincer/llm/cost_tracker.py
+++ b/src/pincer/llm/cost_tracker.py
@@ -40,9 +40,6 @@ PRICING: dict[str, tuple[float, float]] = {
 
 DEFAULT_PRICING = (3.0, 15.0)
 
-# Providers that run locally and incur no API cost.
-FREE_PROVIDERS: frozenset[str] = frozenset({"ollama"})
-
 
 def calculate_cost(model: str, input_tokens: int, output_tokens: int) -> float:
     """Calculate cost in USD for a single API call."""
@@ -110,11 +107,15 @@ class CostTracker:
         input_tokens: int,
         output_tokens: int,
         session_id: str | None = None,
+        is_free: bool = False,
     ) -> float:
-        """Record a cost entry and return the cost. Raises BudgetExceededError if over limit."""
+        """Record a cost entry and return the cost. Raises BudgetExceededError if over limit.
+
+        `is_free` (e.g. a keyless local endpoint) forces zero cost.
+        """
         assert self._db is not None, "CostTracker not initialized"
 
-        cost = 0.0 if provider in FREE_PROVIDERS else calculate_cost(model, input_tokens, output_tokens)
+        cost = 0.0 if is_free else calculate_cost(model, input_tokens, output_tokens)
 
         if cost > 0 and self._daily_budget > 0:
             today_spent = await self.get_today_spend()

--- a/src/pincer/llm/deep_seek_provider.py
+++ b/src/pincer/llm/deep_seek_provider.py
@@ -1,1 +1,0 @@
-"""Deep Seek provider."""

--- a/src/pincer/llm/google_gemini_provider.py
+++ b/src/pincer/llm/google_gemini_provider.py
@@ -1,1 +1,0 @@
-"""Google Gemini provider."""

--- a/src/pincer/llm/groq_provider.py
+++ b/src/pincer/llm/groq_provider.py
@@ -1,1 +1,0 @@
-"""Grok provider."""

--- a/src/pincer/llm/mistral_provider.py
+++ b/src/pincer/llm/mistral_provider.py
@@ -1,1 +1,0 @@
-"""Mistral provider."""

--- a/src/pincer/llm/openai_common.py
+++ b/src/pincer/llm/openai_common.py
@@ -116,6 +116,8 @@ def parse_openai_response(response: ChatCompletion) -> LLMResponse:
 
     if message.tool_calls:
         for tc in message.tool_calls:
+            if tc.type != "function":  # skip non-function (custom) tool calls
+                continue
             try:
                 args = json.loads(tc.function.arguments)
             except json.JSONDecodeError:
@@ -132,62 +134,45 @@ def parse_openai_response(response: ChatCompletion) -> LLMResponse:
     )
 
 
-_MODEL_MAPS: dict[str, dict[str, str]] = {
-    "openai": {
-        "claude-sonnet-4-5-20250929": "gpt-4o",
-        "claude-haiku-4-5-20251001": "gpt-4o-mini",
-    },
-    "grok": {
-        "claude-sonnet-4-5-20250929": "grok-3",
-        "claude-haiku-4-5-20251001": "grok-3-mini",
-        "gpt-4o": "grok-3",
-        "gpt-4o-mini": "grok-3-mini",
-    },
-    "ollama": {
-        "claude-sonnet-4-5-20250929": "llama3.2",
-        "claude-haiku-4-5-20251001": "llama3.2",
-        "gpt-4o": "llama3.2",
-        "gpt-4o-mini": "llama3.2",
-    },
-}
-
-_PROVIDER_DISPLAY_NAMES: dict[str, str] = {
-    "openai": "OpenAI",
-    "grok": "Grok",
-    "ollama": "Ollama",
-}
-
-
 # ── Base class ────────────────────────────────────────────────────────────────
 
 
 class OpenAICompatibleProvider(BaseLLMProvider):
-    """Single class for all OpenAI-compatible providers (OpenAI, Grok, Ollama)."""
+    """Provider for any OpenAI-wire endpoint.
 
-    def __init__(self, settings: Settings) -> None:
-        provider = settings.default_provider.value
-        self._provider_name = _PROVIDER_DISPLAY_NAMES.get(provider, provider.capitalize())
+    `provider == "openai"` uses the well-known API (key + built-in base URL); any
+    other name uses the configured compatible endpoint (base URL + optional key).
+    The model id is passed straight through — no claude→model mapping.
+    """
+
+    def __init__(self, settings: Settings, provider: str) -> None:
+        self._provider_name = provider
 
         if provider == "openai":
             api_key = settings.openai_api_key.get_secret_value()
+            if not api_key:
+                raise ValueError("provider 'openai' needs PINCER_OPENAI_API_KEY")
             base_url = settings.openai_base_url
-        elif provider == "grok":
-            api_key = settings.grok_api_key.get_secret_value()
-            base_url = settings.grok_base_url
-        elif provider == "ollama":
-            api_key = "ollama"
-            base_url = settings.ollama_base_url
+            model = settings.openai_model or settings.default_model
         else:
-            raise ValueError(f"Unsupported OpenAI-compatible provider: {provider!r}")
+            api_key = settings.openai_compatible_api_key.get_secret_value() or "none"
+            base_url = settings.openai_compatible_base_url
+            model = settings.openai_compatible_model or settings.default_model
+
+        # An OpenAI-wire endpoint won't accept an Anthropic-native model id. This
+        # catches PINCER_DEFAULT_MODEL (a claude-* default) leaking onto an OpenAI
+        # provider with no model of its own — fail fast instead of a runtime 404.
+        if model.startswith("claude"):
+            env = "PINCER_OPENAI_MODEL" if provider == "openai" else "PINCER_OPENAI_COMPATIBLE_MODEL"
+            raise ValueError(
+                f"OpenAI-wire provider {provider!r} resolved to model {model!r}, which an OpenAI "
+                f"endpoint will reject. Set {env} to a model this endpoint supports."
+            )
 
         self._client = AsyncOpenAI(api_key=api_key, base_url=base_url, max_retries=2)
-        self._model_map = _MODEL_MAPS.get(provider, {})
-        self._default_model = self._model_map.get(settings.default_model, settings.default_model)
+        self._default_model = model
         self._default_max_tokens = settings.max_tokens
         self._default_temperature = settings.temperature
-
-    def _resolve_model(self, model: str) -> str:
-        return self._model_map.get(model, model)
 
     async def complete(
         self,
@@ -200,7 +185,7 @@ class OpenAICompatibleProvider(BaseLLMProvider):
     ) -> LLMResponse:
         api_messages = convert_messages_to_openai(messages, system)
         kwargs: dict[str, Any] = {
-            "model": self._resolve_model(model) if model else self._default_model,
+            "model": model or self._default_model,
             "max_tokens": max_tokens or self._default_max_tokens,
             "temperature": temperature if temperature is not None else self._default_temperature,
             "messages": api_messages,
@@ -215,7 +200,9 @@ class OpenAICompatibleProvider(BaseLLMProvider):
         except openai.APIConnectionError as e:
             raise LLMError(f"{self._provider_name} connection error: {e}") from e
 
-        return parse_openai_response(response)
+        result = parse_openai_response(response)
+        result.provider = self._provider_name
+        return result
 
     async def stream(
         self,
@@ -228,7 +215,7 @@ class OpenAICompatibleProvider(BaseLLMProvider):
     ) -> AsyncIterator[str]:
         api_messages = convert_messages_to_openai(messages, system)
         kwargs: dict[str, Any] = {
-            "model": self._resolve_model(model) if model else self._default_model,
+            "model": model or self._default_model,
             "max_tokens": max_tokens or self._default_max_tokens,
             "temperature": temperature if temperature is not None else self._default_temperature,
             "messages": api_messages,

--- a/src/pincer/llm/router.py
+++ b/src/pincer/llm/router.py
@@ -1,0 +1,182 @@
+"""
+Single entry point for LLM provider construction + failover.
+
+`LLMRouter` is itself a `BaseLLMProvider`: `complete()`/`stream()` try the primary
+provider and, on failure, fall over to a randomly-ordered failover provider. All
+provider construction lives here — `cli.py` and `api/_deps.py` only call
+`LLMRouter().get_llm()` / `.get_summarizer()`.
+
+Provider names are free-form. `openai`/`anthropic` are well-known (key only); any
+other name must match a configured `*_compatible_provider` (base URL + optional key).
+"""
+
+from __future__ import annotations
+
+import logging
+import random
+from typing import TYPE_CHECKING, Any
+
+from pincer.config import get_settings
+from pincer.exceptions import LLMError, LLMRateLimitError
+from pincer.llm.anthropic_common import AnthropicCompatibleProvider
+from pincer.llm.base import BaseLLMProvider, LLMMessage, LLMResponse
+from pincer.llm.openai_common import OpenAICompatibleProvider
+
+if TYPE_CHECKING:
+    from collections.abc import AsyncIterator
+
+    from pincer.config import Settings
+
+logger = logging.getLogger(__name__)
+
+WELL_KNOWN_PROVIDERS: frozenset[str] = frozenset({"openai", "anthropic"})
+MAX_FAILOVERS = 3
+
+
+def _build_leaf(settings: Settings, name: str) -> BaseLLMProvider:
+    """Resolve a provider name to a constructed provider instance."""
+    if name == "openai":
+        return OpenAICompatibleProvider(settings, "openai")
+    if name == "anthropic":
+        return AnthropicCompatibleProvider(settings, "anthropic")
+    if name and name == settings.openai_compatible_provider:
+        if not settings.openai_compatible_base_url:
+            raise ValueError(f"provider {name!r} needs PINCER_OPENAI_COMPATIBLE_BASE_URL")
+        return OpenAICompatibleProvider(settings, name)
+    if name and name == settings.anthropic_compatible_provider:
+        if not settings.anthropic_compatible_base_url:
+            raise ValueError(f"provider {name!r} needs PINCER_ANTHROPIC_COMPATIBLE_BASE_URL")
+        return AnthropicCompatibleProvider(settings, name)
+    raise ValueError(
+        f"unknown provider {name!r}; expected 'openai', 'anthropic', "
+        f"or a configured PINCER_OPENAI_COMPATIBLE_PROVIDER / PINCER_ANTHROPIC_COMPATIBLE_PROVIDER"
+    )
+
+
+class LLMRouter(BaseLLMProvider):
+    """Single construction + failover entry point. Drop-in `BaseLLMProvider`."""
+
+    def __init__(self) -> None:
+        self._settings = get_settings()
+        self._pool: dict[str, BaseLLMProvider] | None = None
+
+    # ── Construction ─────────────────────────────────────
+
+    def _build_pool(self) -> dict[str, BaseLLMProvider]:
+        """Build every configured provider once (memoised), with validation."""
+        if self._pool is not None:
+            return self._pool
+
+        s = self._settings
+        if len(s.fallback_providers) > MAX_FAILOVERS:
+            raise ValueError(f"At most {MAX_FAILOVERS} failover providers allowed, got {len(s.fallback_providers)}")
+        for cname in (s.openai_compatible_provider, s.anthropic_compatible_provider):
+            if cname in WELL_KNOWN_PROVIDERS:
+                raise ValueError(f"compatible provider name {cname!r} collides with a well-known provider")
+
+        pool: dict[str, BaseLLMProvider] = {}
+        for name in [s.default_provider, *s.fallback_providers]:
+            if name not in pool:
+                pool[name] = _build_leaf(s, name)
+        self._pool = pool
+        return pool
+
+    def _primary_and_failovers(self) -> tuple[BaseLLMProvider, list[BaseLLMProvider]]:
+        pool = self._build_pool()
+        primary = pool[self._settings.default_provider]
+        failovers = [pool[n] for n in self._settings.fallback_providers]
+        return primary, failovers
+
+    # ── Accessors ────────────────────────────────────────
+
+    def get_llm(self) -> BaseLLMProvider:
+        self._build_pool()  # validate eagerly at construction time
+        return self
+
+    def get_summarizer(self) -> BaseLLMProvider:
+        pool = self._build_pool()
+        name = self._settings.summary_provider
+        if name:
+            if name not in pool:
+                raise ValueError(f"summary provider {name!r} not in active pool {list(pool)}")
+            return pool[name]
+        return pool[self._settings.default_provider]
+
+    def is_free(self, provider: str) -> bool:
+        """A provider is free when it has no API key (e.g. a local Ollama endpoint)."""
+        s = self._settings
+        if provider in WELL_KNOWN_PROVIDERS:
+            return False
+        if provider and provider == s.openai_compatible_provider:
+            return s.openai_compatible_api_key.get_secret_value() == ""
+        if provider and provider == s.anthropic_compatible_provider:
+            return s.anthropic_compatible_api_key.get_secret_value() == ""
+        return False
+
+    # ── BaseLLMProvider ──────────────────────────────────
+
+    async def complete(
+        self,
+        messages: list[LLMMessage],
+        tools: list[dict[str, Any]] | None = None,
+        model: str | None = None,
+        max_tokens: int | None = None,
+        temperature: float | None = None,
+        system: str | None = None,
+    ) -> LLMResponse:
+        primary, failovers = self._primary_and_failovers()
+        try:
+            return await primary.complete(
+                messages, tools=tools, model=model, max_tokens=max_tokens, temperature=temperature, system=system
+            )
+        except (LLMError, LLMRateLimitError) as primary_err:
+            for provider in random.sample(failovers, len(failovers)):
+                try:
+                    return await provider.complete(
+                        messages,
+                        tools=tools,
+                        model=model,
+                        max_tokens=max_tokens,
+                        temperature=temperature,
+                        system=system,
+                    )
+                except (LLMError, LLMRateLimitError) as err:
+                    logger.warning("Failover provider failed: %s — trying next", err)
+                    continue
+            raise primary_err
+
+    async def stream(
+        self,
+        messages: list[LLMMessage],
+        tools: list[dict[str, Any]] | None = None,
+        model: str | None = None,
+        max_tokens: int | None = None,
+        temperature: float | None = None,
+        system: str | None = None,
+    ) -> AsyncIterator[str]:
+        primary, failovers = self._primary_and_failovers()
+        ordered = [primary, *random.sample(failovers, len(failovers))]
+        primary_err: Exception | None = None
+        for index, provider in enumerate(ordered):
+            started = False
+            try:
+                async for token in provider.stream(
+                    messages, tools=tools, model=model, max_tokens=max_tokens, temperature=temperature, system=system
+                ):
+                    started = True
+                    yield token
+                return
+            except (LLMError, LLMRateLimitError) as err:
+                if index == 0:
+                    primary_err = err
+                if started:
+                    raise  # mid-stream failure propagates — no mid-stream failover
+                logger.warning("Stream provider %d failed before first token: %s — trying next", index, err)
+                continue
+        if primary_err is not None:
+            raise primary_err
+
+    async def close(self) -> None:
+        if self._pool:
+            for leaf in self._pool.values():
+                await leaf.close()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -20,6 +20,18 @@ from pincer.llm.cost_tracker import CostTracker
 from pincer.tools.registry import ToolRegistry
 
 
+@pytest.fixture(autouse=True)
+def _isolate_dotenv(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Unit tests must not read the developer's project .env file.
+
+    Settings reads env_file=("../.env", ".env") by default; disable it so local
+    config (e.g. PINCER_OPENAI_COMPATIBLE_MODEL) can't leak into assertions. Tests
+    that need a specific dotenv still pass `_env_file=...` explicitly (that init
+    kwarg overrides this).
+    """
+    monkeypatch.setitem(Settings.model_config, "env_file", None)
+
+
 @pytest.fixture
 def settings(tmp_path: Path) -> Settings:
     return Settings(

--- a/tests/test_anthropic_compatible_provider.py
+++ b/tests/test_anthropic_compatible_provider.py
@@ -1,0 +1,429 @@
+"""Tests for AnthropicCompatibleProvider."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from anthropic.types import Message, TextBlock, ToolUseBlock, Usage
+
+from pincer.llm.base import ImageContent, LLMMessage, MessageRole, ToolCall
+
+MODULE = "pincer.llm.anthropic_common"
+
+
+def _make_message(text: str = "Hi!", model: str = "claude-x") -> Message:
+    return Message.model_construct(
+        content=[TextBlock.model_construct(type="text", text=text)],
+        model=model,
+        usage=Usage.model_construct(input_tokens=10, output_tokens=5),
+        stop_reason="end_turn",
+    )
+
+
+@pytest.fixture
+def anthropic_settings():
+    from pincer.config import Settings
+
+    return Settings(
+        anthropic_api_key="sk-ant-test",  # type: ignore[arg-type]
+        telegram_bot_token="123456:TEST",  # type: ignore[arg-type]
+        default_provider="anthropic",
+        default_model="claude-x",
+    )
+
+
+def test_well_known_anthropic_uses_default_endpoint(anthropic_settings):
+    from pincer.llm.anthropic_common import AnthropicCompatibleProvider
+
+    with patch(f"{MODULE}.AsyncAnthropic") as mock_cls:
+        mock_cls.return_value = MagicMock()
+        AnthropicCompatibleProvider(anthropic_settings, "anthropic")
+
+    kwargs = mock_cls.call_args.kwargs
+    assert kwargs["api_key"] == "sk-ant-test"
+    assert kwargs["base_url"] is None
+
+
+def test_compatible_uses_custom_base_url_and_key():
+    from pincer.config import Settings
+    from pincer.llm.anthropic_common import AnthropicCompatibleProvider
+
+    settings = Settings(
+        anthropic_api_key="sk-ant-test",  # type: ignore[arg-type]
+        telegram_bot_token="123456:TEST",  # type: ignore[arg-type]
+        default_provider="my-claude",
+        default_model="claude-x",
+        anthropic_compatible_provider="my-claude",
+        anthropic_compatible_base_url="https://proxy.example/v1",
+        anthropic_compatible_api_key="proxy-key",  # type: ignore[arg-type]
+    )
+
+    with patch(f"{MODULE}.AsyncAnthropic") as mock_cls:
+        mock_cls.return_value = MagicMock()
+        AnthropicCompatibleProvider(settings, "my-claude")
+
+    kwargs = mock_cls.call_args.kwargs
+    assert kwargs["base_url"] == "https://proxy.example/v1"
+    assert kwargs["api_key"] == "proxy-key"
+
+
+def test_compatible_empty_key_uses_placeholder():
+    from pincer.config import Settings
+    from pincer.llm.anthropic_common import AnthropicCompatibleProvider
+
+    settings = Settings(
+        anthropic_api_key="sk-ant-test",  # type: ignore[arg-type]
+        telegram_bot_token="123456:TEST",  # type: ignore[arg-type]
+        default_provider="proxy",
+        anthropic_compatible_provider="proxy",
+        anthropic_compatible_base_url="https://proxy.example/v1",
+    )
+
+    with patch(f"{MODULE}.AsyncAnthropic") as mock_cls:
+        mock_cls.return_value = MagicMock()
+        AnthropicCompatibleProvider(settings, "proxy")
+
+    assert mock_cls.call_args.kwargs["api_key"] == "none"
+
+
+def test_anthropic_model_override():
+    from pincer.config import Settings
+    from pincer.llm.anthropic_common import AnthropicCompatibleProvider
+
+    settings = Settings(
+        anthropic_api_key="sk-ant-test",  # type: ignore[arg-type]
+        telegram_bot_token="123456:TEST",  # type: ignore[arg-type]
+        default_provider="anthropic",
+        default_model="claude-sonnet-4-5-20250929",
+        anthropic_model="claude-opus-4-6",
+        _env_file=None,  # type: ignore[call-arg]
+    )
+    with patch(f"{MODULE}.AsyncAnthropic") as mock_cls:
+        mock_cls.return_value = MagicMock()
+        provider = AnthropicCompatibleProvider(settings, "anthropic")
+    assert provider._default_model == "claude-opus-4-6"
+
+
+def test_anthropic_compatible_model_falls_back_to_default():
+    from pincer.config import Settings
+    from pincer.llm.anthropic_common import AnthropicCompatibleProvider
+
+    settings = Settings(
+        anthropic_api_key="sk-ant-test",  # type: ignore[arg-type]
+        telegram_bot_token="123456:TEST",  # type: ignore[arg-type]
+        default_provider="my-claude",
+        default_model="claude-sonnet-4-5-20250929",
+        anthropic_compatible_provider="my-claude",
+        anthropic_compatible_base_url="https://proxy/v1",
+        # anthropic_compatible_model unset → falls back to default_model
+        _env_file=None,  # type: ignore[call-arg]
+    )
+    with patch(f"{MODULE}.AsyncAnthropic") as mock_cls:
+        mock_cls.return_value = MagicMock()
+        provider = AnthropicCompatibleProvider(settings, "my-claude")
+    assert provider._default_model == "claude-sonnet-4-5-20250929"
+
+
+@pytest.mark.asyncio
+async def test_complete_returns_content(anthropic_settings):
+    from pincer.llm.anthropic_common import AnthropicCompatibleProvider
+
+    with patch(f"{MODULE}.AsyncAnthropic") as mock_cls:
+        mock_client = MagicMock()
+        mock_client.messages.create = AsyncMock(return_value=_make_message("Hello!"))
+        mock_client.close = AsyncMock()
+        mock_cls.return_value = mock_client
+
+        provider = AnthropicCompatibleProvider(anthropic_settings, "anthropic")
+        result = await provider.complete([LLMMessage(role=MessageRole.USER, content="hi")])
+
+    assert result.content == "Hello!"
+    assert result.model == "claude-x"
+    assert result.provider == "anthropic"  # stamps the serving provider
+    assert result.input_tokens == 10
+    assert result.output_tokens == 5
+
+
+def test_missing_anthropic_key_raises():
+    from pincer.config import Settings
+    from pincer.llm.anthropic_common import AnthropicCompatibleProvider
+
+    settings = Settings(
+        anthropic_api_key="",  # type: ignore[arg-type]
+        openai_api_key="sk-oai",  # type: ignore[arg-type]  (some provider must be set)
+        telegram_bot_token="123456:TEST",  # type: ignore[arg-type]
+        default_provider="openai",
+        _env_file=None,  # type: ignore[call-arg]
+    )
+    with patch(f"{MODULE}.AsyncAnthropic"), pytest.raises(ValueError, match="PINCER_ANTHROPIC_API_KEY"):
+        AnthropicCompatibleProvider(settings, "anthropic")
+
+
+@pytest.mark.asyncio
+async def test_complete_parses_tool_use(anthropic_settings):
+    from pincer.llm.anthropic_common import AnthropicCompatibleProvider
+
+    tool_block = ToolUseBlock.model_construct(type="tool_use", id="t1", name="search", input={"q": "x"})
+    msg = Message.model_construct(
+        content=[tool_block],
+        model="claude-x",
+        usage=Usage.model_construct(input_tokens=3, output_tokens=2),
+        stop_reason="tool_use",
+    )
+
+    with patch(f"{MODULE}.AsyncAnthropic") as mock_cls:
+        mock_client = MagicMock()
+        mock_client.messages.create = AsyncMock(return_value=msg)
+        mock_cls.return_value = mock_client
+
+        provider = AnthropicCompatibleProvider(anthropic_settings, "anthropic")
+        result = await provider.complete([LLMMessage(role=MessageRole.USER, content="hi")])
+
+    assert result.has_tool_calls
+    assert result.tool_calls[0].name == "search"
+    assert result.tool_calls[0].arguments == {"q": "x"}
+
+
+@pytest.mark.asyncio
+async def test_complete_passes_system_and_tools(anthropic_settings):
+    from pincer.llm.anthropic_common import AnthropicCompatibleProvider
+
+    with patch(f"{MODULE}.AsyncAnthropic") as mock_cls:
+        mock_client = MagicMock()
+        mock_client.messages.create = AsyncMock(return_value=_make_message())
+        mock_cls.return_value = mock_client
+
+        provider = AnthropicCompatibleProvider(anthropic_settings, "anthropic")
+        tools = [{"name": "t", "description": "d", "input_schema": {"type": "object"}}]
+        await provider.complete(
+            [LLMMessage(role=MessageRole.USER, content="hi")],
+            tools=tools,
+            system="be nice",
+        )
+
+    kwargs = mock_client.messages.create.call_args.kwargs
+    assert kwargs["system"] == "be nice"
+    assert kwargs["tools"] == tools
+
+
+@pytest.mark.asyncio
+async def test_complete_wraps_status_error(anthropic_settings):
+    import anthropic
+
+    from pincer.exceptions import LLMError
+    from pincer.llm.anthropic_common import AnthropicCompatibleProvider
+
+    err = anthropic.APIStatusError("bad", response=MagicMock(status_code=400), body={})
+
+    with patch(f"{MODULE}.AsyncAnthropic") as mock_cls:
+        mock_client = MagicMock()
+        mock_client.messages.create = AsyncMock(side_effect=err)
+        mock_cls.return_value = mock_client
+
+        provider = AnthropicCompatibleProvider(anthropic_settings, "anthropic")
+        with pytest.raises(LLMError, match="Anthropic API error"):
+            await provider.complete([LLMMessage(role=MessageRole.USER, content="hi")])
+
+
+@pytest.mark.asyncio
+async def test_convert_handles_images_tool_results(anthropic_settings):
+    """Exercise the message-conversion branches (images, tool_use, tool_result)."""
+    from pincer.llm.anthropic_common import AnthropicCompatibleProvider
+
+    with patch(f"{MODULE}.AsyncAnthropic") as mock_cls:
+        mock_client = MagicMock()
+        mock_client.messages.create = AsyncMock(return_value=_make_message())
+        mock_cls.return_value = mock_client
+
+        provider = AnthropicCompatibleProvider(anthropic_settings, "anthropic")
+        messages = [
+            LLMMessage(role=MessageRole.SYSTEM, content="ignored"),
+            LLMMessage(
+                role=MessageRole.USER,
+                content="look",
+                images=[ImageContent(data="abc", media_type="image/png")],
+            ),
+            LLMMessage(
+                role=MessageRole.ASSISTANT,
+                content="calling",
+                tool_calls=[ToolCall(id="t1", name="search", arguments={"q": "x"})],
+            ),
+            LLMMessage(role=MessageRole.TOOL_RESULT, content="result", tool_call_id="t1"),
+        ]
+        await provider.complete(messages)
+
+    sent = mock_client.messages.create.call_args.kwargs["messages"]
+    assert sent[0]["role"] == "user"  # first message must be user
+
+
+@pytest.mark.asyncio
+async def test_stream_yields_text(anthropic_settings):
+    from pincer.llm.anthropic_common import AnthropicCompatibleProvider
+
+    async def _text_stream():
+        for t in ["He", "llo"]:
+            yield t
+
+    stream_cm = MagicMock()
+    stream_cm.__aenter__ = AsyncMock(return_value=MagicMock(text_stream=_text_stream()))
+    stream_cm.__aexit__ = AsyncMock(return_value=False)
+
+    with patch(f"{MODULE}.AsyncAnthropic") as mock_cls:
+        mock_client = MagicMock()
+        mock_client.messages.stream = MagicMock(return_value=stream_cm)
+        mock_cls.return_value = mock_client
+
+        provider = AnthropicCompatibleProvider(anthropic_settings, "anthropic")
+        result = [t async for t in provider.stream([LLMMessage(role=MessageRole.USER, content="hi")])]
+
+    assert result == ["He", "llo"]
+
+
+@pytest.mark.asyncio
+async def test_complete_retries_then_succeeds(anthropic_settings):
+    import anthropic
+
+    from pincer.llm.anthropic_common import AnthropicCompatibleProvider
+
+    rate_err = anthropic.RateLimitError("slow down", response=MagicMock(headers={"retry-after": "0"}), body={})
+    create = AsyncMock(side_effect=[rate_err, _make_message("after retry")])
+
+    with patch(f"{MODULE}.AsyncAnthropic") as mock_cls, patch(f"{MODULE}.asyncio.sleep", new_callable=AsyncMock):
+        mock_client = MagicMock()
+        mock_client.messages.create = create
+        mock_cls.return_value = mock_client
+
+        provider = AnthropicCompatibleProvider(anthropic_settings, "anthropic")
+        result = await provider.complete([LLMMessage(role=MessageRole.USER, content="hi")])
+
+    assert result.content == "after retry"
+    assert create.call_count == 2
+
+
+@pytest.mark.asyncio
+async def test_complete_rate_limit_exhausted(anthropic_settings):
+    import anthropic
+
+    from pincer.exceptions import LLMRateLimitError
+    from pincer.llm.anthropic_common import AnthropicCompatibleProvider
+
+    rate_err = anthropic.RateLimitError("slow down", response=MagicMock(headers={"retry-after": "0"}), body={})
+
+    with patch(f"{MODULE}.AsyncAnthropic") as mock_cls, patch(f"{MODULE}.asyncio.sleep", new_callable=AsyncMock):
+        mock_client = MagicMock()
+        mock_client.messages.create = AsyncMock(side_effect=rate_err)
+        mock_cls.return_value = mock_client
+
+        provider = AnthropicCompatibleProvider(anthropic_settings, "anthropic")
+        with pytest.raises(LLMRateLimitError):
+            await provider.complete([LLMMessage(role=MessageRole.USER, content="hi")])
+
+
+@pytest.mark.asyncio
+async def test_stream_rate_limit_error(anthropic_settings):
+    import anthropic
+
+    from pincer.exceptions import LLMRateLimitError
+    from pincer.llm.anthropic_common import AnthropicCompatibleProvider
+
+    rate_err = anthropic.RateLimitError("slow down", response=MagicMock(headers={"retry-after": "1"}), body={})
+    stream_cm = MagicMock()
+    stream_cm.__aenter__ = AsyncMock(side_effect=rate_err)
+    stream_cm.__aexit__ = AsyncMock(return_value=False)
+
+    with patch(f"{MODULE}.AsyncAnthropic") as mock_cls:
+        mock_client = MagicMock()
+        mock_client.messages.stream = MagicMock(return_value=stream_cm)
+        mock_cls.return_value = mock_client
+
+        provider = AnthropicCompatibleProvider(anthropic_settings, "anthropic")
+        with pytest.raises(LLMRateLimitError):
+            async for _ in provider.stream([LLMMessage(role=MessageRole.USER, content="hi")]):
+                pass
+
+
+@pytest.mark.asyncio
+async def test_stream_status_error(anthropic_settings):
+    import anthropic
+
+    from pincer.exceptions import LLMError
+    from pincer.llm.anthropic_common import AnthropicCompatibleProvider
+
+    err = anthropic.APIStatusError("server", response=MagicMock(status_code=500), body={})
+    stream_cm = MagicMock()
+    stream_cm.__aenter__ = AsyncMock(side_effect=err)
+    stream_cm.__aexit__ = AsyncMock(return_value=False)
+
+    with patch(f"{MODULE}.AsyncAnthropic") as mock_cls:
+        mock_client = MagicMock()
+        mock_client.messages.stream = MagicMock(return_value=stream_cm)
+        mock_cls.return_value = mock_client
+
+        provider = AnthropicCompatibleProvider(anthropic_settings, "anthropic")
+        with pytest.raises(LLMError, match="stream error"):
+            async for _ in provider.stream([LLMMessage(role=MessageRole.USER, content="hi")]):
+                pass
+
+
+@pytest.mark.asyncio
+async def test_complete_connection_error(anthropic_settings):
+    import anthropic
+
+    from pincer.exceptions import LLMError
+    from pincer.llm.anthropic_common import AnthropicCompatibleProvider
+
+    err = anthropic.APIConnectionError(request=MagicMock())
+
+    with patch(f"{MODULE}.AsyncAnthropic") as mock_cls:
+        mock_client = MagicMock()
+        mock_client.messages.create = AsyncMock(side_effect=err)
+        mock_cls.return_value = mock_client
+
+        provider = AnthropicCompatibleProvider(anthropic_settings, "anthropic")
+        with pytest.raises(LLMError, match="connection error"):
+            await provider.complete([LLMMessage(role=MessageRole.USER, content="hi")])
+
+
+@pytest.mark.asyncio
+async def test_validate_merges_and_drops_orphans(anthropic_settings):
+    """Consecutive same-role messages merge; orphaned tool_use is stripped."""
+    from pincer.llm.anthropic_common import AnthropicCompatibleProvider
+
+    with patch(f"{MODULE}.AsyncAnthropic") as mock_cls:
+        mock_client = MagicMock()
+        mock_client.messages.create = AsyncMock(return_value=_make_message())
+        mock_cls.return_value = mock_client
+
+        provider = AnthropicCompatibleProvider(anthropic_settings, "anthropic")
+        messages = [
+            LLMMessage(role=MessageRole.USER, content="one"),
+            LLMMessage(role=MessageRole.USER, content="two"),
+            # orphaned tool_use (no matching tool_result) → dropped
+            LLMMessage(
+                role=MessageRole.ASSISTANT,
+                content="",
+                tool_calls=[ToolCall(id="orphan", name="t", arguments={})],
+            ),
+        ]
+        await provider.complete(messages)
+
+    sent = mock_client.messages.create.call_args.kwargs["messages"]
+    # the two consecutive user messages were merged into one
+    assert sent[0]["role"] == "user"
+    assert "one" in sent[0]["content"] and "two" in sent[0]["content"]
+
+
+@pytest.mark.asyncio
+async def test_close(anthropic_settings):
+    from pincer.llm.anthropic_common import AnthropicCompatibleProvider
+
+    with patch(f"{MODULE}.AsyncAnthropic") as mock_cls:
+        mock_client = MagicMock()
+        mock_client.close = AsyncMock()
+        mock_cls.return_value = mock_client
+
+        provider = AnthropicCompatibleProvider(anthropic_settings, "anthropic")
+        await provider.close()
+
+    mock_client.close.assert_awaited_once()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -143,9 +143,13 @@ async def test_chat_loop_degrades_mcp_memory_backend(
 
     monkeypatch.setattr("pincer.config.get_settings", lambda: mock_settings)
     monkeypatch.setattr("pincer.cli._create_memory_backend", lambda _s: fake_memory)
+    mock_router = MagicMock()
+    mock_router.get_llm.return_value = mock_llm
+    mock_router.get_summarizer.return_value = mock_llm
+
     monkeypatch.setattr("pincer.core.session.SessionManager", MagicMock(return_value=mock_session))
     monkeypatch.setattr("pincer.llm.cost_tracker.CostTracker", MagicMock(return_value=mock_cost))
-    monkeypatch.setattr("pincer.llm.anthropic_provider.AnthropicProvider", MagicMock(return_value=mock_llm))
+    monkeypatch.setattr("pincer.llm.router.LLMRouter", MagicMock(return_value=mock_router))
     monkeypatch.setattr("pincer.core.agent.Agent", MagicMock(return_value=mock_agent))
 
     # Exit the input loop immediately on first prompt
@@ -198,9 +202,13 @@ async def test_chat_loop_creates_summarizer_for_non_mcp_memory(
 
     monkeypatch.setattr("pincer.config.get_settings", lambda: mock_settings)
     monkeypatch.setattr("pincer.cli._create_memory_backend", lambda _s: fake_memory)
+    mock_router = MagicMock()
+    mock_router.get_llm.return_value = mock_llm
+    mock_router.get_summarizer.return_value = mock_llm
+
     monkeypatch.setattr("pincer.core.session.SessionManager", MagicMock(return_value=AsyncMock()))
     monkeypatch.setattr("pincer.llm.cost_tracker.CostTracker", MagicMock(return_value=AsyncMock()))
-    monkeypatch.setattr("pincer.llm.anthropic_provider.AnthropicProvider", MagicMock(return_value=mock_llm))
+    monkeypatch.setattr("pincer.llm.router.LLMRouter", MagicMock(return_value=mock_router))
     monkeypatch.setattr("pincer.memory.summarizer.Summarizer", _mock_summarizer)
     monkeypatch.setattr("pincer.core.agent.Agent", MagicMock(return_value=MagicMock()))
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -19,33 +19,59 @@ def test_settings_load_from_env(tmp_path: Path, monkeypatch: pytest.MonkeyPatch)
     assert s.max_tokens == 8192
 
 
-def test_settings_fallback_to_openai(tmp_path: Path) -> None:
+def test_settings_accepts_openai_only(tmp_path: Path) -> None:
     s = Settings(
         anthropic_api_key="",  # type: ignore[arg-type]
         openai_api_key="sk-openai-test",  # type: ignore[arg-type]
         data_dir=tmp_path,
-        default_provider=LLMProvider.ANTHROPIC,
+        default_provider="openai",
     )
-    assert s.default_provider == LLMProvider.OPENAI
+    assert s.default_provider == "openai"
+    assert s.openai_api_key.get_secret_value() == "sk-openai-test"
 
 
-def test_settings_no_keys_raises(tmp_path: Path) -> None:
-    with pytest.raises(ValueError, match="At least one LLM API key"):
+def test_settings_no_providers_raises(tmp_path: Path) -> None:
+    with pytest.raises(ValueError, match="At least one LLM provider"):
         Settings(
-            default_provider=LLMProvider.ANTHROPIC,  # type: ignore[arg-type]
+            default_provider="anthropic",
             anthropic_api_key="",  # type: ignore[arg-type]
             openai_api_key="",  # type: ignore[arg-type]
-            grok_api_key="",  # type: ignore[arg-type]
             data_dir=tmp_path,
+            _env_file=None,  # hermetic: ignore the developer's .env  # type: ignore[call-arg]
         )
 
 
-def test_ollama_requires_no_api_key(tmp_path: Path) -> None:
+def test_compatible_base_url_satisfies_validation(tmp_path: Path) -> None:
+    # e.g. Ollama: no API key, just a compatible base URL.
     s = Settings(
-        default_provider=LLMProvider.OLLAMA,  # type: ignore[arg-type]
+        default_provider="ollama",
+        anthropic_api_key="",  # type: ignore[arg-type]
+        openai_api_key="",  # type: ignore[arg-type]
+        openai_compatible_provider="ollama",
+        openai_compatible_base_url="http://localhost:11434/v1",
         data_dir=tmp_path,
     )
-    assert s.default_provider == LLMProvider.OLLAMA
+    assert s.default_provider == "ollama"
+
+
+def test_fallback_providers_from_env_comma_string(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    # Regression: PINCER_FALLBACK_PROVIDERS must parse a comma string from the
+    # environment (pydantic-settings would otherwise try to JSON-decode the list).
+    monkeypatch.setenv("PINCER_FALLBACK_PROVIDERS", "openai,grok")
+    s = Settings(anthropic_api_key="sk-test", data_dir=tmp_path)  # type: ignore[arg-type]
+    assert s.fallback_providers == ["openai", "grok"]
+
+
+def test_parse_fallback_providers_comma_string() -> None:
+    assert Settings.parse_fallback_providers("openai, grok ,my-claude") == ["openai", "grok", "my-claude"]
+
+
+def test_parse_fallback_providers_empty() -> None:
+    assert Settings.parse_fallback_providers("") == []
+
+
+def test_parse_fallback_providers_list_passthrough() -> None:
+    assert Settings.parse_fallback_providers(["openai", "grok"]) == ["openai", "grok"]
 
 
 def test_parse_allowed_users() -> None:

--- a/tests/test_llm.py
+++ b/tests/test_llm.py
@@ -50,6 +50,18 @@ async def test_cost_tracker_record(cost_tracker: CostTracker) -> None:
 
 
 @pytest.mark.asyncio
+async def test_cost_tracker_record_free_provider(cost_tracker: CostTracker) -> None:
+    cost = await cost_tracker.record(
+        provider="ollama",
+        model="llama3.2",
+        input_tokens=1000,
+        output_tokens=500,
+        is_free=True,
+    )
+    assert cost == 0.0
+
+
+@pytest.mark.asyncio
 async def test_cost_tracker_summary(cost_tracker: CostTracker) -> None:
     await cost_tracker.record("test", "gpt-4o", 100, 50)
     await cost_tracker.record("test", "gpt-4o", 200, 100)
@@ -59,3 +71,38 @@ async def test_cost_tracker_summary(cost_tracker: CostTracker) -> None:
     assert summary.total_input_tokens == 300
     assert summary.total_output_tokens == 150
     assert summary.total_usd > 0
+
+
+@pytest.mark.asyncio
+async def test_cost_tracker_image_and_budget(cost_tracker: CostTracker) -> None:
+    await cost_tracker.add_image_cost(0.05, provider="fal", model="nano-banana")
+    assert await cost_tracker.get_image_count_today() == 1
+    assert await cost_tracker.get_today_spend() >= 0.05
+
+    status = await cost_tracker.get_budget_status()
+    assert status["daily_limit"] == 100.0
+    assert status["spent_today"] >= 0.05
+    assert status["remaining"] <= 100.0
+
+
+@pytest.mark.asyncio
+async def test_cost_tracker_reporting_queries(cost_tracker: CostTracker) -> None:
+    from datetime import UTC, datetime
+
+    await cost_tracker.record("test", "gpt-4o", 100, 50)
+    today = datetime.now(UTC).strftime("%Y-%m-%d")
+
+    daily = await cost_tracker.get_daily_costs(today)
+    assert daily["request_count"] == 1
+    assert "gpt-4o" in daily["by_model"]
+
+    history = await cost_tracker.get_daily_history(today, today)
+    assert history and history[0]["requests"] == 1
+
+    by_model = await cost_tracker.get_costs_by_model(today, today)
+    assert by_model[0]["model"] == "gpt-4o"
+
+    assert await cost_tracker.get_costs_by_tool(today, today) == []
+
+    summary = await cost_tracker.get_summary(since_timestamp=1.0)
+    assert summary.total_calls == 1

--- a/tests/test_openai_compatible_provider.py
+++ b/tests/test_openai_compatible_provider.py
@@ -9,7 +9,7 @@ import pytest
 
 from pincer.llm.base import LLMMessage, MessageRole
 
-MODULE = "pincer.llm._openai_common"
+MODULE = "pincer.llm.openai_common"
 
 
 def _make_chat_completion(content: str = "Hello!", model: str = "test-model"):
@@ -49,14 +49,14 @@ def openai_settings():
     return Settings(
         openai_api_key="sk-test",  # type: ignore[arg-type]
         telegram_bot_token="123456:TEST",  # type: ignore[arg-type]
-        default_provider="openai",  # type: ignore[arg-type]
+        default_provider="openai",
         default_model="my-model",
     )
 
 
 @pytest.mark.asyncio
 async def test_complete_returns_content(openai_settings):
-    from pincer.llm._openai_common import OpenAICompatibleProvider
+    from pincer.llm.openai_common import OpenAICompatibleProvider
 
     fake_response = _make_chat_completion("Hi!")
 
@@ -66,26 +66,73 @@ async def test_complete_returns_content(openai_settings):
         mock_client.close = AsyncMock()
         mock_cls.return_value = mock_client
 
-        provider = OpenAICompatibleProvider(openai_settings)
+        provider = OpenAICompatibleProvider(openai_settings, "openai")
         result = await provider.complete([LLMMessage(role=MessageRole.USER, content="hi")])
 
     assert result.content == "Hi!"
     assert result.input_tokens == 10
     assert result.output_tokens == 5
+    assert result.provider == "openai"  # stamps the serving provider for cost attribution
 
 
-@pytest.mark.asyncio
-async def test_model_map_remaps_model_name(openai_settings):
+def test_missing_openai_key_raises():
     from pincer.config import Settings
-    from pincer.llm._openai_common import OpenAICompatibleProvider
+    from pincer.llm.openai_common import OpenAICompatibleProvider
+
+    settings = Settings(
+        anthropic_api_key="sk-ant",  # type: ignore[arg-type]  (some provider must be set)
+        openai_api_key="",  # type: ignore[arg-type]
+        telegram_bot_token="123456:TEST",  # type: ignore[arg-type]
+        default_provider="anthropic",
+        default_model="gpt-4o",
+        _env_file=None,  # type: ignore[call-arg]
+    )
+    with patch(f"{MODULE}.AsyncOpenAI"), pytest.raises(ValueError, match="PINCER_OPENAI_API_KEY"):
+        OpenAICompatibleProvider(settings, "openai")
+
+
+def test_claude_model_on_openai_wire_raises():
+    from pincer.config import Settings
+    from pincer.llm.openai_common import OpenAICompatibleProvider
 
     settings = Settings(
         openai_api_key="sk-test",  # type: ignore[arg-type]
         telegram_bot_token="123456:TEST",  # type: ignore[arg-type]
-        default_provider="openai",  # type: ignore[arg-type]
-        default_model="claude-sonnet-4-5-20250929",
+        default_provider="openai",
+        default_model="claude-sonnet-4-5-20250929",  # claude default with no openai_model
+        _env_file=None,  # type: ignore[call-arg]
     )
-    fake_response = _make_chat_completion(model="gpt-4o")
+    with patch(f"{MODULE}.AsyncOpenAI"), pytest.raises(ValueError, match="PINCER_OPENAI_MODEL"):
+        OpenAICompatibleProvider(settings, "openai")
+
+
+@pytest.mark.asyncio
+async def test_well_known_openai_uses_key_and_base_url(openai_settings):
+    from pincer.llm.openai_common import OpenAICompatibleProvider
+
+    with patch(f"{MODULE}.AsyncOpenAI") as mock_cls:
+        mock_cls.return_value = MagicMock()
+        OpenAICompatibleProvider(openai_settings, "openai")
+
+    kwargs = mock_cls.call_args.kwargs
+    assert kwargs["api_key"] == "sk-test"
+    assert kwargs["base_url"] == "https://api.openai.com/v1"
+
+
+@pytest.mark.asyncio
+async def test_compatible_uses_compatible_base_url_and_passthrough_model():
+    from pincer.config import Settings
+    from pincer.llm.openai_common import OpenAICompatibleProvider
+
+    settings = Settings(
+        telegram_bot_token="123456:TEST",  # type: ignore[arg-type]
+        default_provider="grok",
+        default_model="grok-3",
+        openai_compatible_provider="grok",
+        openai_compatible_base_url="https://api.x.ai/v1",
+        openai_compatible_api_key="xai-key",  # type: ignore[arg-type]
+    )
+    fake_response = _make_chat_completion(model="grok-3")
 
     with patch(f"{MODULE}.AsyncOpenAI") as mock_cls:
         mock_client = MagicMock()
@@ -93,11 +140,157 @@ async def test_model_map_remaps_model_name(openai_settings):
         mock_client.close = AsyncMock()
         mock_cls.return_value = mock_client
 
-        provider = OpenAICompatibleProvider(settings)
+        provider = OpenAICompatibleProvider(settings, "grok")
         await provider.complete([LLMMessage(role=MessageRole.USER, content="hi")])
 
-    call_kwargs = mock_client.chat.completions.create.call_args.kwargs
-    assert call_kwargs["model"] == "gpt-4o"
+    init_kwargs = mock_cls.call_args.kwargs
+    assert init_kwargs["base_url"] == "https://api.x.ai/v1"
+    assert init_kwargs["api_key"] == "xai-key"
+    # model passed straight through — no remapping
+    assert mock_client.chat.completions.create.call_args.kwargs["model"] == "grok-3"
+
+
+@pytest.mark.asyncio
+async def test_per_provider_model_overrides_default():
+    """A compatible endpoint uses its own model, not the primary's default_model."""
+    from pincer.config import Settings
+    from pincer.llm.openai_common import OpenAICompatibleProvider
+
+    settings = Settings(
+        anthropic_api_key="sk-ant",  # type: ignore[arg-type]
+        telegram_bot_token="123456:TEST",  # type: ignore[arg-type]
+        default_provider="anthropic",
+        default_model="claude-sonnet-4-5-20250929",  # primary's model
+        openai_compatible_provider="ollama",
+        openai_compatible_base_url="http://localhost:11434/v1",
+        openai_compatible_model="llama3.2",  # failover's own model
+        _env_file=None,  # type: ignore[call-arg]
+    )
+    fake_response = _make_chat_completion(model="llama3.2")
+
+    with patch(f"{MODULE}.AsyncOpenAI") as mock_cls:
+        mock_client = MagicMock()
+        mock_client.chat.completions.create = AsyncMock(return_value=fake_response)
+        mock_cls.return_value = mock_client
+
+        provider = OpenAICompatibleProvider(settings, "ollama")
+        await provider.complete([LLMMessage(role=MessageRole.USER, content="hi")])
+
+    # uses the compatible endpoint's model, NOT default_model (claude-…)
+    assert mock_client.chat.completions.create.call_args.kwargs["model"] == "llama3.2"
+
+
+@pytest.mark.asyncio
+async def test_well_known_openai_model_override():
+    from pincer.config import Settings
+    from pincer.llm.openai_common import OpenAICompatibleProvider
+
+    settings = Settings(
+        openai_api_key="sk-test",  # type: ignore[arg-type]
+        telegram_bot_token="123456:TEST",  # type: ignore[arg-type]
+        default_provider="anthropic",
+        anthropic_api_key="sk-ant",  # type: ignore[arg-type]
+        default_model="claude-sonnet-4-5-20250929",
+        openai_model="gpt-4o",
+        _env_file=None,  # type: ignore[call-arg]
+    )
+    with patch(f"{MODULE}.AsyncOpenAI") as mock_cls:
+        mock_cls.return_value = MagicMock()
+        provider = OpenAICompatibleProvider(settings, "openai")
+
+    assert provider._default_model == "gpt-4o"
+
+
+@pytest.mark.asyncio
+async def test_compatible_empty_key_uses_placeholder():
+    from pincer.config import Settings
+    from pincer.llm.openai_common import OpenAICompatibleProvider
+
+    settings = Settings(
+        telegram_bot_token="123456:TEST",  # type: ignore[arg-type]
+        default_provider="ollama",
+        default_model="llama3.2",
+        openai_compatible_provider="ollama",
+        openai_compatible_base_url="http://localhost:11434/v1",
+    )
+
+    with patch(f"{MODULE}.AsyncOpenAI") as mock_cls:
+        mock_cls.return_value = MagicMock()
+        OpenAICompatibleProvider(settings, "ollama")
+
+    assert mock_cls.call_args.kwargs["api_key"] == "none"
+
+
+@pytest.mark.asyncio
+async def test_complete_converts_complex_messages(openai_settings):
+    from pincer.llm.base import ImageContent, ToolCall
+    from pincer.llm.openai_common import OpenAICompatibleProvider
+
+    with patch(f"{MODULE}.AsyncOpenAI") as mock_cls:
+        mock_client = MagicMock()
+        mock_client.chat.completions.create = AsyncMock(return_value=_make_chat_completion())
+        mock_cls.return_value = mock_client
+
+        provider = OpenAICompatibleProvider(openai_settings, "openai")
+        messages = [
+            LLMMessage(role=MessageRole.SYSTEM, content="sys"),
+            LLMMessage(
+                role=MessageRole.USER,
+                content="look",
+                images=[ImageContent(data="abc", media_type="image/png")],
+            ),
+            LLMMessage(
+                role=MessageRole.ASSISTANT,
+                content="calling",
+                tool_calls=[ToolCall(id="t1", name="search", arguments={"q": "x"})],
+            ),
+            LLMMessage(role=MessageRole.TOOL_RESULT, content="res", tool_call_id="t1"),
+        ]
+        await provider.complete(messages, system="top-system")
+
+    sent = mock_client.chat.completions.create.call_args.kwargs["messages"]
+    assert sent[0] == {"role": "system", "content": "top-system"}
+    roles = [m["role"] for m in sent]
+    assert "tool" in roles and "assistant" in roles
+
+
+@pytest.mark.asyncio
+async def test_complete_parses_tool_calls(openai_settings):
+    import json
+
+    from pincer.llm.openai_common import OpenAICompatibleProvider
+
+    tc = MagicMock()
+    tc.id = "call_1"
+    tc.type = "function"
+    tc.function.name = "search"
+    tc.function.arguments = json.dumps({"q": "x"})
+
+    message = MagicMock()
+    message.content = None
+    message.tool_calls = [tc]
+    choice = MagicMock()
+    choice.message = message
+    choice.finish_reason = "tool_calls"
+    usage = MagicMock()
+    usage.prompt_tokens = 1
+    usage.completion_tokens = 1
+    response = MagicMock()
+    response.choices = [choice]
+    response.model = "my-model"
+    response.usage = usage
+
+    with patch(f"{MODULE}.AsyncOpenAI") as mock_cls:
+        mock_client = MagicMock()
+        mock_client.chat.completions.create = AsyncMock(return_value=response)
+        mock_cls.return_value = mock_client
+
+        provider = OpenAICompatibleProvider(openai_settings, "openai")
+        result = await provider.complete([LLMMessage(role=MessageRole.USER, content="hi")])
+
+    assert result.has_tool_calls
+    assert result.tool_calls[0].name == "search"
+    assert result.tool_calls[0].arguments == {"q": "x"}
 
 
 @pytest.mark.asyncio
@@ -105,7 +298,7 @@ async def test_connection_error_includes_provider_name(openai_settings):
     import openai
 
     from pincer.exceptions import LLMError
-    from pincer.llm._openai_common import OpenAICompatibleProvider
+    from pincer.llm.openai_common import OpenAICompatibleProvider
 
     with patch(f"{MODULE}.AsyncOpenAI") as mock_cls:
         mock_client = MagicMock()
@@ -113,52 +306,15 @@ async def test_connection_error_includes_provider_name(openai_settings):
         mock_client.close = AsyncMock()
         mock_cls.return_value = mock_client
 
-        provider = OpenAICompatibleProvider(openai_settings)
-        with pytest.raises(LLMError, match="OpenAI connection error"):
+        provider = OpenAICompatibleProvider(openai_settings, "openai")
+        with pytest.raises(LLMError, match="connection error"):
             await provider.complete([LLMMessage(role=MessageRole.USER, content="hi")])
-
-
-@pytest.fixture
-def grok_settings():
-    from pincer.config import Settings
-
-    return Settings(
-        grok_api_key="grok-test-key",  # type: ignore[arg-type]
-        telegram_bot_token="123456:TEST",  # type: ignore[arg-type]
-        default_provider="grok",  # type: ignore[arg-type]
-        default_model="grok-3",
-    )
-
-
-@pytest.mark.asyncio
-async def test_grok_provider_initialises(grok_settings):
-    from pincer.llm._openai_common import OpenAICompatibleProvider
-
-    with patch(f"{MODULE}.AsyncOpenAI") as mock_cls:
-        mock_cls.return_value = MagicMock()
-        provider = OpenAICompatibleProvider(grok_settings)
-
-    assert provider._provider_name == "Grok"
-
-
-def test_unsupported_provider_raises():
-    from pincer.config.main import Settings
-    from pincer.llm._openai_common import OpenAICompatibleProvider
-
-    settings = Settings(
-        openai_api_key="sk-x",  # type: ignore[arg-type]
-        telegram_bot_token="123456:TEST",  # type: ignore[arg-type]
-        default_provider="openai",  # type: ignore[arg-type]
-    )
-    object.__setattr__(settings, "default_provider", type("P", (), {"value": "unsupported"})())
-    with patch(f"{MODULE}.AsyncOpenAI"), pytest.raises(ValueError, match="Unsupported"):
-        OpenAICompatibleProvider(settings)
 
 
 @pytest.mark.asyncio
 async def test_complete_api_status_error(openai_settings):
     from pincer.exceptions import LLMError
-    from pincer.llm._openai_common import OpenAICompatibleProvider
+    from pincer.llm.openai_common import OpenAICompatibleProvider
 
     with patch(f"{MODULE}.AsyncOpenAI") as mock_cls:
         mock_client = MagicMock()
@@ -168,7 +324,7 @@ async def test_complete_api_status_error(openai_settings):
         mock_client.close = AsyncMock()
         mock_cls.return_value = mock_client
 
-        provider = OpenAICompatibleProvider(openai_settings)
+        provider = OpenAICompatibleProvider(openai_settings, "openai")
         with pytest.raises(LLMError, match="400"):
             await provider.complete([LLMMessage(role=MessageRole.USER, content="hi")])
 
@@ -188,7 +344,7 @@ def _make_async_iterable(chunks):
 
 @pytest.mark.asyncio
 async def test_stream_yields_content(openai_settings):
-    from pincer.llm._openai_common import OpenAICompatibleProvider
+    from pincer.llm.openai_common import OpenAICompatibleProvider
 
     chunks = [_make_stream_chunk("Hello"), _make_stream_chunk(" world"), _make_stream_chunk(None)]
 
@@ -198,7 +354,7 @@ async def test_stream_yields_content(openai_settings):
         mock_client.close = AsyncMock()
         mock_cls.return_value = mock_client
 
-        provider = OpenAICompatibleProvider(openai_settings)
+        provider = OpenAICompatibleProvider(openai_settings, "openai")
         result = [t async for t in provider.stream([LLMMessage(role=MessageRole.USER, content="hi")])]
 
     assert result == ["Hello", " world"]
@@ -206,7 +362,7 @@ async def test_stream_yields_content(openai_settings):
 
 @pytest.mark.asyncio
 async def test_stream_with_tools(openai_settings):
-    from pincer.llm._openai_common import OpenAICompatibleProvider
+    from pincer.llm.openai_common import OpenAICompatibleProvider
 
     chunks = [_make_stream_chunk("ok")]
 
@@ -224,7 +380,7 @@ async def test_stream_with_tools(openai_settings):
         mock_client.close = AsyncMock()
         mock_cls.return_value = mock_client
 
-        provider = OpenAICompatibleProvider(openai_settings)
+        provider = OpenAICompatibleProvider(openai_settings, "openai")
         tools = [{"name": "my_tool", "description": "a tool", "input_schema": {"type": "object", "properties": {}}}]
         result = [t async for t in provider.stream([LLMMessage(role=MessageRole.USER, content="hi")], tools=tools)]
 
@@ -234,7 +390,7 @@ async def test_stream_with_tools(openai_settings):
 @pytest.mark.asyncio
 async def test_stream_rate_limit_error(openai_settings):
     from pincer.exceptions import LLMRateLimitError
-    from pincer.llm._openai_common import OpenAICompatibleProvider
+    from pincer.llm.openai_common import OpenAICompatibleProvider
 
     async def _raise(**kwargs):
         raise _openai.RateLimitError("rate limited", response=MagicMock(status_code=429), body={})
@@ -245,7 +401,7 @@ async def test_stream_rate_limit_error(openai_settings):
         mock_client.close = AsyncMock()
         mock_cls.return_value = mock_client
 
-        provider = OpenAICompatibleProvider(openai_settings)
+        provider = OpenAICompatibleProvider(openai_settings, "openai")
         with pytest.raises(LLMRateLimitError):
             async for _ in provider.stream([LLMMessage(role=MessageRole.USER, content="hi")]):
                 pass
@@ -254,7 +410,7 @@ async def test_stream_rate_limit_error(openai_settings):
 @pytest.mark.asyncio
 async def test_stream_api_status_error(openai_settings):
     from pincer.exceptions import LLMError
-    from pincer.llm._openai_common import OpenAICompatibleProvider
+    from pincer.llm.openai_common import OpenAICompatibleProvider
 
     async def _raise(**kwargs):
         raise _openai.APIStatusError("server error", response=MagicMock(status_code=500), body={})
@@ -265,7 +421,7 @@ async def test_stream_api_status_error(openai_settings):
         mock_client.close = AsyncMock()
         mock_cls.return_value = mock_client
 
-        provider = OpenAICompatibleProvider(openai_settings)
+        provider = OpenAICompatibleProvider(openai_settings, "openai")
         with pytest.raises(LLMError, match="500"):
             async for _ in provider.stream([LLMMessage(role=MessageRole.USER, content="hi")]):
                 pass
@@ -274,7 +430,7 @@ async def test_stream_api_status_error(openai_settings):
 @pytest.mark.asyncio
 async def test_retry_on_rate_limit_exhausted(openai_settings):
     from pincer.exceptions import LLMRateLimitError
-    from pincer.llm._openai_common import OpenAICompatibleProvider
+    from pincer.llm.openai_common import OpenAICompatibleProvider
 
     call_count = 0
 
@@ -289,24 +445,8 @@ async def test_retry_on_rate_limit_exhausted(openai_settings):
         mock_client.close = AsyncMock()
         mock_cls.return_value = mock_client
 
-        provider = OpenAICompatibleProvider(openai_settings)
+        provider = OpenAICompatibleProvider(openai_settings, "openai")
         with pytest.raises(LLMRateLimitError):
             await provider.complete([LLMMessage(role=MessageRole.USER, content="hi")])
 
     assert call_count == 3  # max_retries=3
-
-
-def test_build_llm_returns_openai_compatible_for_openai():
-    from pincer.api._deps import _build_llm
-    from pincer.config import Settings
-    from pincer.llm._openai_common import OpenAICompatibleProvider
-
-    settings = Settings(
-        openai_api_key="sk-test",  # type: ignore[arg-type]
-        telegram_bot_token="123456:TEST",  # type: ignore[arg-type]
-        default_provider="openai",  # type: ignore[arg-type]
-    )
-    with patch(f"{MODULE}.AsyncOpenAI"):
-        provider = _build_llm(settings)
-
-    assert isinstance(provider, OpenAICompatibleProvider)

--- a/tests/test_provider_ollama.py
+++ b/tests/test_provider_ollama.py
@@ -37,25 +37,26 @@ def ollama_settings():
     return Settings(
         anthropic_api_key="sk-ant-test",  # type: ignore[arg-type]
         telegram_bot_token="123456:TEST",  # type: ignore[arg-type]
-        default_provider="ollama",  # type: ignore[arg-type]
+        default_provider="ollama",
         default_model="llama3.2",
-        ollama_base_url="http://localhost:11434/v1",
+        openai_compatible_provider="ollama",
+        openai_compatible_base_url="http://localhost:11434/v1",
     )
 
 
 @pytest.mark.asyncio
 async def test_complete_returns_content(ollama_settings):
-    from pincer.llm._openai_common import OpenAICompatibleProvider
+    from pincer.llm.openai_common import OpenAICompatibleProvider
 
     fake_response = _make_chat_completion("Hi from Ollama!")
 
-    with patch("pincer.llm._openai_common.AsyncOpenAI") as mock_cls:
+    with patch("pincer.llm.openai_common.AsyncOpenAI") as mock_cls:
         mock_client = MagicMock()
         mock_client.chat.completions.create = AsyncMock(return_value=fake_response)
         mock_client.close = AsyncMock()
         mock_cls.return_value = mock_client
 
-        provider = OpenAICompatibleProvider(ollama_settings)
+        provider = OpenAICompatibleProvider(ollama_settings, "ollama")
         messages = [LLMMessage(role=MessageRole.USER, content="Say hi")]
         response = await provider.complete(messages)
 
@@ -79,7 +80,7 @@ def _make_stream_chunk(content: str | None):
 
 @pytest.mark.asyncio
 async def test_stream_yields_text_chunks(ollama_settings):
-    from pincer.llm._openai_common import OpenAICompatibleProvider
+    from pincer.llm.openai_common import OpenAICompatibleProvider
 
     chunks = [_make_stream_chunk("Hello"), _make_stream_chunk(" world"), _make_stream_chunk(None)]
 
@@ -87,13 +88,13 @@ async def test_stream_yields_text_chunks(ollama_settings):
         for chunk in chunks:
             yield chunk
 
-    with patch("pincer.llm._openai_common.AsyncOpenAI") as mock_cls:
+    with patch("pincer.llm.openai_common.AsyncOpenAI") as mock_cls:
         mock_client = MagicMock()
         mock_client.chat.completions.create = AsyncMock(return_value=_aiter())
         mock_client.close = AsyncMock()
         mock_cls.return_value = mock_client
 
-        provider = OpenAICompatibleProvider(ollama_settings)
+        provider = OpenAICompatibleProvider(ollama_settings, "ollama")
         messages = [LLMMessage(role=MessageRole.USER, content="Say hi")]
         result = [token async for token in provider.stream(messages)]
 
@@ -102,17 +103,17 @@ async def test_stream_yields_text_chunks(ollama_settings):
 
 @pytest.mark.asyncio
 async def test_complete_passes_tools_in_openai_format(ollama_settings):
-    from pincer.llm._openai_common import OpenAICompatibleProvider
+    from pincer.llm.openai_common import OpenAICompatibleProvider
 
     fake_response = _make_chat_completion()
 
-    with patch("pincer.llm._openai_common.AsyncOpenAI") as mock_cls:
+    with patch("pincer.llm.openai_common.AsyncOpenAI") as mock_cls:
         mock_client = MagicMock()
         mock_client.chat.completions.create = AsyncMock(return_value=fake_response)
         mock_client.close = AsyncMock()
         mock_cls.return_value = mock_client
 
-        provider = OpenAICompatibleProvider(ollama_settings)
+        provider = OpenAICompatibleProvider(ollama_settings, "ollama")
         messages = [LLMMessage(role=MessageRole.USER, content="Use a tool")]
         tools = [{"name": "search", "description": "Search the web", "input_schema": {"type": "object"}}]
         await provider.complete(messages, tools=tools)
@@ -128,16 +129,16 @@ async def test_complete_wraps_connection_error(ollama_settings):
     import openai
 
     from pincer.exceptions import LLMError
-    from pincer.llm._openai_common import OpenAICompatibleProvider
+    from pincer.llm.openai_common import OpenAICompatibleProvider
 
-    with patch("pincer.llm._openai_common.AsyncOpenAI") as mock_cls:
+    with patch("pincer.llm.openai_common.AsyncOpenAI") as mock_cls:
         mock_client = MagicMock()
         mock_client.chat.completions.create = AsyncMock(side_effect=openai.APIConnectionError(request=MagicMock()))
         mock_client.close = AsyncMock()
         mock_cls.return_value = mock_client
 
-        provider = OpenAICompatibleProvider(ollama_settings)
+        provider = OpenAICompatibleProvider(ollama_settings, "ollama")
         messages = [LLMMessage(role=MessageRole.USER, content="hello")]
 
-        with pytest.raises(LLMError, match="Ollama connection error"):
+        with pytest.raises(LLMError, match="connection error"):
             await provider.complete(messages)

--- a/tests/test_router.py
+++ b/tests/test_router.py
@@ -1,0 +1,325 @@
+"""Tests for LLMRouter — construction, resolution, failover, summary, is_free."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from pincer.exceptions import LLMError
+from pincer.llm.base import BaseLLMProvider, LLMResponse
+from pincer.llm.router import LLMRouter
+
+
+class FakeProvider(BaseLLMProvider):
+    """Configurable in-memory provider for exercising router logic."""
+
+    def __init__(
+        self,
+        name: str,
+        *,
+        complete_fail: bool = False,
+        stream_tokens: list[str] | None = None,
+        stream_fail_before: bool = False,
+        stream_fail_after: bool = False,
+    ) -> None:
+        self.name = name
+        self.complete_fail = complete_fail
+        self.stream_tokens = stream_tokens or []
+        self.stream_fail_before = stream_fail_before
+        self.stream_fail_after = stream_fail_after
+        self.complete_calls = 0
+        self.closed = False
+
+    async def complete(self, messages=None, **kwargs):  # type: ignore[override]
+        self.complete_calls += 1
+        if self.complete_fail:
+            raise LLMError(f"{self.name} boom")
+        return LLMResponse(content=f"from {self.name}", model=self.name, provider=self.name)
+
+    async def stream(self, messages=None, **kwargs):  # type: ignore[override]
+        if self.stream_fail_before:
+            raise LLMError(f"{self.name} stream boom")
+        for token in self.stream_tokens:
+            yield token
+        if self.stream_fail_after:
+            raise LLMError(f"{self.name} stream mid boom")
+
+    async def close(self) -> None:
+        self.closed = True
+
+
+def _router_with_pool(default, failovers, pool, *, summary_provider=None):
+    r = LLMRouter.__new__(LLMRouter)
+    r._settings = SimpleNamespace(
+        default_provider=default,
+        fallback_providers=failovers,
+        summary_provider=summary_provider,
+    )
+    r._pool = pool
+    return r
+
+
+# ── complete() failover ──────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_complete_primary_success_no_failover():
+    primary = FakeProvider("primary")
+    fb = FakeProvider("fb")
+    r = _router_with_pool("primary", ["fb"], {"primary": primary, "fb": fb})
+
+    result = await r.complete(messages=[])
+
+    assert result.content == "from primary"
+    assert fb.complete_calls == 0
+
+
+@pytest.mark.asyncio
+async def test_complete_fails_over_and_reports_serving_provider():
+    primary = FakeProvider("primary", complete_fail=True)
+    fb = FakeProvider("fb")
+    r = _router_with_pool("primary", ["fb"], {"primary": primary, "fb": fb})
+
+    result = await r.complete(messages=[])
+
+    assert result.model == "fb"  # LLMResponse.model reflects the serving provider
+    assert result.provider == "fb"  # and so does .provider (used for cost attribution)
+
+
+@pytest.mark.asyncio
+async def test_complete_all_fail_reraises_primary_error():
+    primary = FakeProvider("primary", complete_fail=True)
+    fb1 = FakeProvider("fb1", complete_fail=True)
+    fb2 = FakeProvider("fb2", complete_fail=True)
+    r = _router_with_pool("primary", ["fb1", "fb2"], {"primary": primary, "fb1": fb1, "fb2": fb2})
+
+    with pytest.raises(LLMError, match="primary boom"):
+        await r.complete(messages=[])
+
+
+@pytest.mark.asyncio
+async def test_complete_second_failover_serves_when_first_fails():
+    primary = FakeProvider("primary", complete_fail=True)
+    fb1 = FakeProvider("fb1", complete_fail=True)
+    fb2 = FakeProvider("fb2")
+    r = _router_with_pool("primary", ["fb1", "fb2"], {"primary": primary, "fb1": fb1, "fb2": fb2})
+
+    # Deterministic order so fb1 is tried first (and fails), then fb2 serves.
+    with patch("pincer.llm.router.random.sample", side_effect=lambda seq, n: list(seq)):
+        result = await r.complete(messages=[])
+
+    assert result.model == "fb2"
+
+
+# ── stream() failover ─────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_stream_fails_over_before_first_token():
+    primary = FakeProvider("primary", stream_fail_before=True)
+    fb = FakeProvider("fb", stream_tokens=["He", "llo"])
+    r = _router_with_pool("primary", ["fb"], {"primary": primary, "fb": fb})
+
+    tokens = [t async for t in r.stream(messages=[])]
+
+    assert tokens == ["He", "llo"]
+
+
+@pytest.mark.asyncio
+async def test_stream_no_failover_after_first_token():
+    primary = FakeProvider("primary", stream_tokens=["a"], stream_fail_after=True)
+    fb = FakeProvider("fb", stream_tokens=["b"])
+    r = _router_with_pool("primary", ["fb"], {"primary": primary, "fb": fb})
+
+    collected: list[str] = []
+    with pytest.raises(LLMError):
+        async for token in r.stream(messages=[]):
+            collected.append(token)
+
+    assert collected == ["a"]  # mid-stream error propagates; failover NOT used
+
+
+@pytest.mark.asyncio
+async def test_stream_primary_success():
+    primary = FakeProvider("primary", stream_tokens=["x", "y"])
+    r = _router_with_pool("primary", [], {"primary": primary})
+
+    tokens = [t async for t in r.stream(messages=[])]
+    assert tokens == ["x", "y"]
+
+
+# ── close ──────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_close_closes_every_leaf():
+    primary = FakeProvider("primary")
+    fb = FakeProvider("fb")
+    r = _router_with_pool("primary", ["fb"], {"primary": primary, "fb": fb})
+
+    await r.close()
+
+    assert primary.closed and fb.closed
+
+
+# ── summary selection (§4) ──────────────────────────────────────────────────────
+
+
+def test_get_summarizer_defaults_to_primary():
+    primary = FakeProvider("primary")
+    fb = FakeProvider("fb")
+    r = _router_with_pool("primary", ["fb"], {"primary": primary, "fb": fb})
+
+    assert r.get_summarizer() is primary
+
+
+def test_get_summarizer_uses_configured_provider():
+    primary = FakeProvider("primary")
+    fb = FakeProvider("fb")
+    r = _router_with_pool("primary", ["fb"], {"primary": primary, "fb": fb}, summary_provider="fb")
+
+    assert r.get_summarizer() is fb
+
+
+def test_get_summarizer_not_in_pool_raises():
+    primary = FakeProvider("primary")
+    r = _router_with_pool("primary", [], {"primary": primary}, summary_provider="ghost")
+
+    with pytest.raises(ValueError, match="not in active pool"):
+        r.get_summarizer()
+
+
+# ── resolution / validation (real Settings, mocked clients) ─────────────────────
+
+
+def _settings(**overrides):
+    from pincer.config import Settings
+
+    base = {
+        "anthropic_api_key": "sk-ant",
+        "telegram_bot_token": "123456:TEST",
+        "default_provider": "anthropic",
+        # Hermetic: ignore the developer's .env so compatible base URLs etc. don't leak in.
+        "_env_file": None,
+    }
+    base.update(overrides)
+    return Settings(**base)  # type: ignore[arg-type]
+
+
+def _patched_clients():
+    return (
+        patch("pincer.llm.openai_common.AsyncOpenAI", MagicMock()),
+        patch("pincer.llm.anthropic_common.AsyncAnthropic", MagicMock()),
+    )
+
+
+def test_pool_resolves_well_known_and_both_compatible():
+    from pincer.llm.anthropic_common import AnthropicCompatibleProvider
+    from pincer.llm.openai_common import OpenAICompatibleProvider
+
+    settings = _settings(
+        default_provider="anthropic",
+        fallback_providers=["grok", "my-claude"],
+        openai_compatible_provider="grok",
+        openai_compatible_base_url="https://api.x.ai/v1",
+        openai_compatible_model="grok-3",  # OpenAI-wire can't use the claude default
+        anthropic_compatible_provider="my-claude",
+        anthropic_compatible_base_url="https://proxy/v1",
+    )
+    oai, ant = _patched_clients()
+    with oai, ant, patch("pincer.llm.router.get_settings", return_value=settings):
+        router = LLMRouter()
+        router.get_llm()
+        pool = router._build_pool()
+
+    assert isinstance(pool["anthropic"], AnthropicCompatibleProvider)
+    assert isinstance(pool["grok"], OpenAICompatibleProvider)
+    assert isinstance(pool["my-claude"], AnthropicCompatibleProvider)
+
+
+def test_pool_leaves_carry_their_own_models():
+    """Primary uses default_model; an Ollama-style failover uses its own model."""
+    settings = _settings(
+        default_provider="anthropic",
+        default_model="claude-sonnet-4-5-20250929",
+        fallback_providers=["ollama"],
+        openai_compatible_provider="ollama",
+        openai_compatible_base_url="http://localhost:11434/v1",
+        openai_compatible_model="llama3.2",
+    )
+    oai, ant = _patched_clients()
+    with oai, ant, patch("pincer.llm.router.get_settings", return_value=settings):
+        router = LLMRouter()
+        pool = router._build_pool()
+
+    assert pool["anthropic"]._default_model == "claude-sonnet-4-5-20250929"
+    assert pool["ollama"]._default_model == "llama3.2"
+
+
+def test_pool_rejects_too_many_failovers():
+    settings = _settings(fallback_providers=["a", "b", "c", "d"])
+    with (
+        patch("pincer.llm.router.get_settings", return_value=settings),
+        pytest.raises(ValueError, match="At most 3 failover"),
+    ):
+        LLMRouter().get_llm()
+
+
+def test_unknown_provider_raises():
+    settings = _settings(default_provider="mystery")
+    oai, ant = _patched_clients()
+    with (
+        oai,
+        ant,
+        patch("pincer.llm.router.get_settings", return_value=settings),
+        pytest.raises(ValueError, match="unknown provider"),
+    ):
+        LLMRouter().get_llm()
+
+
+def test_compatible_provider_collision_raises():
+    settings = _settings(
+        openai_compatible_provider="openai",
+        openai_compatible_base_url="https://x/v1",
+    )
+    with patch("pincer.llm.router.get_settings", return_value=settings), pytest.raises(ValueError, match="collides"):
+        LLMRouter().get_llm()
+
+
+def test_compatible_missing_base_url_raises():
+    settings = _settings(
+        default_provider="grok",
+        openai_compatible_provider="grok",
+        # no base_url configured
+    )
+    oai, ant = _patched_clients()
+    with (
+        oai,
+        ant,
+        patch("pincer.llm.router.get_settings", return_value=settings),
+        pytest.raises(ValueError, match="PINCER_OPENAI_COMPATIBLE_BASE_URL"),
+    ):
+        LLMRouter().get_llm()
+
+
+# ── is_free ─────────────────────────────────────────────────────────────────────
+
+
+def test_is_free():
+    settings = _settings(
+        openai_compatible_provider="ollama",
+        openai_compatible_base_url="http://localhost:11434/v1",
+        anthropic_compatible_provider="paid-proxy",
+        anthropic_compatible_base_url="https://proxy/v1",
+        anthropic_compatible_api_key="key",
+    )
+    with patch("pincer.llm.router.get_settings", return_value=settings):
+        router = LLMRouter()
+
+    assert router.is_free("openai") is False
+    assert router.is_free("anthropic") is False
+    assert router.is_free("ollama") is True  # compatible endpoint, no key
+    assert router.is_free("paid-proxy") is False  # compatible endpoint, has key
+    assert router.is_free("unknown") is False


### PR DESCRIPTION
## What

Centralises all LLM provider construction behind a single `LLMRouter` (`pincer.llm.router`) and adds **1 + N random failover**: a primary provider plus up to 3 failovers, with the router falling over to a randomly-chosen failover on `LLMError`/`LLMRateLimitError`. Introduces free-form provider names (well-known `openai`/`anthropic` need only a key; anything else — Grok, Ollama, proxies, gateways — is a named OpenAI-/Anthropic-**compatible** endpoint configured via base URL), per-provider models, a configurable summarizer provider, and serving-provider cost attribution.

## Why

Fixes #140. Provider construction was scattered across `cli.py` (×2) and `api/_deps.py`, the system supported exactly one provider with no resilience, the Summarizer was hard-wired to whatever the CLI built, and there was no way to target an Anthropic-wire endpoint without forking `AnthropicProvider`.

## How

- **`LLMRouter(BaseLLMProvider)`** is the single entry point and is itself the failover provider; `cli.py`/`api/_deps.py` just call `LLMRouter().get_llm()` / `.get_summarizer()`. Adding a provider now touches only `pincer/llm/`.
- **Provider resolution by name**: `openai`/`anthropic` are well-known (key + built-in base URL); any other name must match a configured `PINCER_OPENAI_COMPATIBLE_PROVIDER` / `PINCER_ANTHROPIC_COMPATIBLE_PROVIDER` (base URL + optional key). A custom OpenAI-wire and a custom Anthropic-wire endpoint can coexist as primary/failovers.
- **Per-provider models** (`PINCER_*_MODEL`, each defaulting to `PINCER_DEFAULT_MODEL`) so failover targets a model the endpoint actually has.
- **Cost attribution to the serving provider**: `LLMResponse.provider` carries the provider that actually served (the failover, when used); cost/`is_free` are recorded against it. `is_free` (keyless endpoint → \$0) replaces the hardcoded `FREE_PROVIDERS` set.
- **Fail-fast validation** at pool build: missing well-known key, or a model that the endpoint's wire format will reject, raises a clear error instead of a runtime 401/404.
- Removed `grok`/`ollama` as named providers and the claude→model maps (migration documented); renamed `_openai_common.py`→`openai_common.py`, `anthropic_provider.py`→`anthropic_common.py`; deleted 4 empty stub modules.

### Notable decisions
- `BaseLLMProvider.stream` changed from `async def` to `def` returning `AsyncIterator` (type-only refinement for clean mypy; runtime contract unchanged).
- One compatible endpoint per wire format (one `*_COMPATIBLE_*` set each).

## Testing

- [x] Unit tests added/updated — new `test_router.py`, `test_anthropic_compatible_provider.py`; updated provider/config/cli/cost tests. **Full suite: 1977 passing.**
- [x] Manual testing done — verified failover resolution, per-provider models, and cost attribution against a live Ollama + Anthropic setup.
- [x] `pincer doctor` run — **28 passed, 3 warnings, 1 critical**, all local-environment/hygiene issues unrelated to this PR (world-readable `.env` file perms → `chmod 600`; outdated `anthropic` dep; tool-approval mode `auto`; unset *optional* MCP env vars). The LLM provider/config checks pass.

CI parity run locally (the `pincer` job): pytest+coverage (2112 passed), `mypy src/` clean, `ruff check .` clean, `ruff format --check .` clean, `bandit` no issues. Coverage on changed LLM modules ≥92%.

## Checklist

- [x] Code follows project conventions
- [x] Self-review completed (ran `/code-review`; fixed cost-attribution + fail-fast validation findings)
- [x] Documentation updated — README provider section (fast + extended configs), quickstart, development, project-structure, cli reference, contributing, `.env.example`
- [x] No sensitive data (API keys, tokens) in code — `.env` is gitignored and not committed
- [x] Changelog updated

Fixes #140
