### PR TITLE
feat(ms365-mcp): encrypt per-identity token cache at rest with Fernet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+#### ms365-mcp: encrypted token cache at rest
+
+- Per-identity Microsoft 365 token caches (`<MS365_TOKEN_CACHE_DIR>/<identity>_token_cache.json`) are now encrypted at rest with a shared Fernet key, auto-generated on first run at `MS365_TOKEN_ENCRYPTION_KEY_PATH` (default `~/.pincer/ms365_mcp/token_encryption.key`, mode `0600`), or overridden with `MS365_TOKEN_ENCRYPTION_KEY` (raw key, e.g. injected by a secrets manager). A cache file that fails to decrypt (wrong/rotated key, corruption, or a stray pre-encryption plaintext file) is treated as "no cached token" — the identity re-authenticates rather than crashing the server.
+
 #### Multi-provider LLM architecture with random failover
 
 - **`LLMRouter`** — a single construction entry point (`pincer.llm.router`) that also *is* a `BaseLLMProvider`. `cli.py` and `api/_deps.py` now call `LLMRouter().get_llm()` / `.get_summarizer()`; adding a provider touches only `pincer/llm/`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-#### ms365-mcp: encrypted token cache at rest
+#### ms365-mcp: opt-in encrypted token cache at rest
 
-- Per-identity Microsoft 365 token caches (`<MS365_TOKEN_CACHE_DIR>/<identity>_token_cache.json`) are now encrypted at rest with a shared Fernet key, auto-generated on first run at `MS365_TOKEN_ENCRYPTION_KEY_PATH` (default `~/.pincer/ms365_mcp/token_encryption.key`, mode `0600`), or overridden with `MS365_TOKEN_ENCRYPTION_KEY` (raw key, e.g. injected by a secrets manager). A cache file that fails to decrypt (wrong/rotated key, corruption, or a stray pre-encryption plaintext file) is treated as "no cached token" — the identity re-authenticates rather than crashing the server.
+- Per-identity Microsoft 365 token caches (`<MS365_TOKEN_CACHE_DIR>/<identity>_token_cache.json`) can now be encrypted at rest — set `MS365_TOKEN_ENCRYPTION_KEY` to a Fernet key to enable it; unset, caches remain plaintext. No on-disk key file or auto-generation — the env var is the only source of the key.
+- Existing plaintext per-identity caches are migrated to encrypted storage in place, automatically, the first time each identity's cache is loaded after a key is configured — no re-authentication needed.
+- The pre-per-identity single-account cache (`~/.pincer/ms365_token_cache.json`) is imported as the `default` identity's cache the first time a caller with no/absent identity is resolved, then removed.
+- A cache file that can't be used (wrong/rotated key, corruption) is treated as "no cached token" rather than crashing the server; if the key is removed after being used, the now-unreadable file is deleted and that identity is prompted to re-authenticate.
 
 #### Multi-provider LLM architecture with random failover
 

--- a/docs/core-components/tools.md
+++ b/docs/core-components/tools.md
@@ -119,7 +119,7 @@ Full Meet REST v2 surface — spaces, conference records, participants, recordin
 
 ## Microsoft 365 (69 tools)
 
-Available via the standalone `ms365-mcp` server. Run `ms365-mcp-setup` once to authenticate; a token is cached at `~/.pincer/ms365_token_cache.json`.
+Available via the standalone `ms365-mcp` server. Run `ms365-mcp-setup` once to authenticate; a token is cached (encrypted at rest) at `~/.pincer/ms365_mcp/default_token_cache.json`.
 
 ### Outlook Email (17) — `outlook__`
 

--- a/docs/core-components/tools.md
+++ b/docs/core-components/tools.md
@@ -119,7 +119,7 @@ Full Meet REST v2 surface — spaces, conference records, participants, recordin
 
 ## Microsoft 365 (69 tools)
 
-Available via the standalone `ms365-mcp` server. Run `ms365-mcp-setup` once to authenticate; a token is cached (encrypted at rest) at `~/.pincer/ms365_mcp/default_token_cache.json`.
+Available via the standalone `ms365-mcp` server. Run `ms365-mcp-setup` once to authenticate; a token is cached at `~/.pincer/ms365_mcp/default_token_cache.json` (encrypted at rest if `MS365_TOKEN_ENCRYPTION_KEY` is set, plaintext otherwise).
 
 ### Outlook Email (17) — `outlook__`
 

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -159,7 +159,7 @@ To unlock Outlook email, Calendar, OneDrive, To Do, Teams, Contacts, and OneNote
    ms365-mcp-setup
    ```
 
-The token is cached locally at `~/.pincer/ms365_token_cache.json` (readable only by you).
+The token is cached locally, encrypted at rest, at `~/.pincer/ms365_mcp/default_token_cache.json` (readable only by you).
 
 See [Microsoft 365 MCP Guide](../guides/ms365-mcp.md) for detailed instructions.
 

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -159,7 +159,7 @@ To unlock Outlook email, Calendar, OneDrive, To Do, Teams, Contacts, and OneNote
    ms365-mcp-setup
    ```
 
-The token is cached locally, encrypted at rest, at `~/.pincer/ms365_mcp/default_token_cache.json` (readable only by you).
+The token is cached locally at `~/.pincer/ms365_mcp/default_token_cache.json` (readable only by you; encrypted at rest if `MS365_TOKEN_ENCRYPTION_KEY` is set).
 
 See [Microsoft 365 MCP Guide](../guides/ms365-mcp.md) for detailed instructions.
 

--- a/docs/guides/ms365-mcp.md
+++ b/docs/guides/ms365-mcp.md
@@ -174,8 +174,17 @@ Each identity's MSAL token cache is a separate file:
 
 `identity` is sanitized to a safe filename component before use. Refresh is
 automatic — MSAL rewrites the cache using the cached refresh token. **The
-cache is plaintext** (protected only by filesystem permissions) — encrypting
-it at rest is a known follow-up, not yet implemented.
+cache is encrypted at rest** with a shared Fernet key: auto-generated on
+first run at `MS365_TOKEN_ENCRYPTION_KEY_PATH` (default
+`~/.pincer/ms365_mcp/token_encryption.key`, file mode `0600`), or overridden
+entirely with `MS365_TOKEN_ENCRYPTION_KEY` (a raw Fernet key — useful when
+injecting the key from an external secrets manager instead of a local file).
+One key is shared across all identities on a given server; per-identity
+isolation comes from separate cache files, not separate keys. A file that
+fails to decrypt (wrong/rotated key, corruption, or a stray plaintext file
+left over from before this was added) is treated as "no cached token" —
+the affected identity is prompted to re-authenticate rather than crashing
+the server.
 
 ### `ms365-mcp-setup` (optional, single-identity convenience)
 
@@ -506,9 +515,14 @@ plus `ms365__check_auth_status`).
 
 - **Token storage.** Each identity's cache file is written with mode `0600`
   under `MS365_TOKEN_CACHE_DIR` (default `~/.pincer/ms365_mcp/`). Treat these
-  as credentials — they contain refresh tokens. They are **not encrypted at
-  rest** (filesystem permissions only) — this is a known limitation, not yet
-  addressed.
+  as credentials — they contain refresh tokens. They are **encrypted at rest**
+  with a Fernet key (see [Token storage](#token-storage) above) — note the key
+  file itself is also only protected by filesystem permissions, so this
+  doesn't help against an attacker with full read access to your account, but
+  it does protect against the cache file leaking independently of the key
+  (backups, cloud sync, accidentally archived/committed, etc.). Losing or
+  rotating the key invalidates all cached tokens; affected identities simply
+  re-authenticate.
 - **`identity` is untrusted input.** It's sanitized before being used as part
   of a filename, but never assume it has any particular shape — it's an
   opaque string from whatever MCP host set it.

--- a/docs/guides/ms365-mcp.md
+++ b/docs/guides/ms365-mcp.md
@@ -173,18 +173,43 @@ Each identity's MSAL token cache is a separate file:
 ```
 
 `identity` is sanitized to a safe filename component before use. Refresh is
-automatic — MSAL rewrites the cache using the cached refresh token. **The
-cache is encrypted at rest** with a shared Fernet key: auto-generated on
-first run at `MS365_TOKEN_ENCRYPTION_KEY_PATH` (default
-`~/.pincer/ms365_mcp/token_encryption.key`, file mode `0600`), or overridden
-entirely with `MS365_TOKEN_ENCRYPTION_KEY` (a raw Fernet key — useful when
-injecting the key from an external secrets manager instead of a local file).
+automatic — MSAL rewrites the cache using the cached refresh token.
+
+**Encryption at rest is opt-in.** By default, caches are plaintext. Set
+`MS365_TOKEN_ENCRYPTION_KEY` to a raw Fernet key to enable encryption for
+every identity's cache on that server — there's no on-disk key file to
+manage, and no auto-generation; the env var is the only source of the key.
+Generate one with:
+
+```bash
+python -c "from cryptography.fernet import Fernet; print(Fernet.generate_key().decode())"
+```
+
 One key is shared across all identities on a given server; per-identity
-isolation comes from separate cache files, not separate keys. A file that
-fails to decrypt (wrong/rotated key, corruption, or a stray plaintext file
-left over from before this was added) is treated as "no cached token" —
-the affected identity is prompted to re-authenticate rather than crashing
-the server.
+isolation comes from separate cache files, not separate keys.
+
+Setting the key for the first time on a deployment that already has
+plaintext per-identity caches (e.g. from before this feature existed)
+migrates each one to encrypted storage in place, automatically, the next
+time that identity's cache is loaded — no action needed, and no
+re-authentication required.
+
+Removing `MS365_TOKEN_ENCRYPTION_KEY` after it's been in use makes any
+previously-encrypted cache unreadable; the next time an affected identity's
+cache is loaded, the now-unreadable file is deleted and that identity is
+prompted to re-authenticate — this happens lazily, per identity, not as an
+immediate bulk sweep. Rotating to a *different* key (still set, just
+changed) instead leaves the old file in place with a warning logged, since
+that could be a transient misconfiguration rather than a deliberate move
+away from encryption — corruption is handled the same way.
+
+**Migrating from the pre-per-identity single-account cache.** Before the
+per-identity scheme existed, `ms365-mcp` (and its predecessor) kept one
+global cache at `~/.pincer/ms365_token_cache.json`. The first time a caller
+with no/absent identity is resolved (the `"default"` identity slot), that
+legacy file — if present — is imported as the default identity's cache
+(encrypted too, if a key is configured) and then deleted. Back it up first
+if you want to keep a copy.
 
 ### `ms365-mcp-setup` (optional, single-identity convenience)
 
@@ -515,13 +540,14 @@ plus `ms365__check_auth_status`).
 
 - **Token storage.** Each identity's cache file is written with mode `0600`
   under `MS365_TOKEN_CACHE_DIR` (default `~/.pincer/ms365_mcp/`). Treat these
-  as credentials — they contain refresh tokens. They are **encrypted at rest**
-  with a Fernet key (see [Token storage](#token-storage) above) — note the key
-  file itself is also only protected by filesystem permissions, so this
-  doesn't help against an attacker with full read access to your account, but
-  it does protect against the cache file leaking independently of the key
-  (backups, cloud sync, accidentally archived/committed, etc.). Losing or
-  rotating the key invalidates all cached tokens; affected identities simply
+  as credentials — they contain refresh tokens. Encryption at rest is
+  **opt-in** via `MS365_TOKEN_ENCRYPTION_KEY` (see [Token storage](#token-storage)
+  above) — by default, caches are plaintext. Protect the key env var like any
+  other credential; unlike the cache files it isn't a local file at all, so
+  it protects against the cache leaking independently (backups, cloud sync,
+  accidentally archived/committed, etc.) rather than against an attacker with
+  full read access to your account/process environment. Removing or rotating
+  the key invalidates previously-encrypted caches; affected identities simply
   re-authenticate.
 - **`identity` is untrusted input.** It's sanitized before being used as part
   of a filename, but never assume it has any particular shape — it's an

--- a/src/ms365-mcp/ms365/auth.py
+++ b/src/ms365-mcp/ms365/auth.py
@@ -21,7 +21,12 @@ import logging
 import os
 import sys
 from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any
+
+from cryptography.fernet import InvalidToken
+
+if TYPE_CHECKING:
+    from cryptography.fernet import Fernet
 
 logger = logging.getLogger(__name__)
 
@@ -70,6 +75,7 @@ class MS365Auth:
         cache_path: str,
         tenant_id: str = "common",
         services: list[str] | None = None,
+        fernet: Fernet | None = None,
     ) -> None:
         self._client_id = client_id
         self._tenant_id = tenant_id
@@ -78,6 +84,7 @@ class MS365Auth:
         self._app: Any = None  # msal.PublicClientApplication
         self._cache: Any = None  # msal.SerializableTokenCache
         self._pending_flow_message: str = ""
+        self._fernet = fernet
 
     def _ensure_app(self) -> None:
         """Lazily initialise the MSAL application."""
@@ -96,14 +103,31 @@ class MS365Auth:
         )
 
     def _load_cache(self) -> None:
-        if self._cache_path.exists():
-            self._cache.deserialize(self._cache_path.read_text())
+        if not self._cache_path.exists():
+            return
+        raw = self._cache_path.read_bytes()
+        if self._fernet is not None:
+            try:
+                raw = self._fernet.decrypt(raw)
+            except InvalidToken:
+                logger.warning(
+                    "Token cache at %s could not be decrypted (wrong/rotated key, corrupt "
+                    "file, or a stray unencrypted legacy cache) — treating as no cached "
+                    "token; re-authentication will be required.",
+                    self._cache_path,
+                )
+                return
+        self._cache.deserialize(raw.decode("utf-8"))
 
     def _save_cache(self) -> None:
-        if self._cache.has_state_changed:
-            self._cache_path.parent.mkdir(parents=True, exist_ok=True)
-            self._cache_path.write_text(self._cache.serialize())
-            os.chmod(self._cache_path, 0o600)
+        if not self._cache.has_state_changed:
+            return
+        data = self._cache.serialize().encode("utf-8")
+        if self._fernet is not None:
+            data = self._fernet.encrypt(data)
+        self._cache_path.parent.mkdir(parents=True, exist_ok=True)
+        self._cache_path.write_bytes(data)
+        os.chmod(self._cache_path, 0o600)
 
     # ── Public API ────────────────────────────────────────────────────────────
 

--- a/src/ms365-mcp/ms365/auth.py
+++ b/src/ms365-mcp/ms365/auth.py
@@ -17,6 +17,7 @@ Run ``ms365-mcp-setup`` to perform a one-time device code auth flow for the
 from __future__ import annotations
 
 import asyncio
+import json
 import logging
 import os
 import sys
@@ -29,6 +30,10 @@ if TYPE_CHECKING:
     from cryptography.fernet import Fernet
 
 logger = logging.getLogger(__name__)
+
+# Before the per-identity cache scheme (issue #154), ms365-mcp kept a single
+# global token cache here. Confirmed via `git show fca49ff:src/pincer/integrations/ms365/config.py`.
+LEGACY_CACHE_PATH = Path.home() / ".pincer" / "ms365_token_cache.json"
 
 # Scopes grouped by service.
 SERVICE_SCOPES: dict[str, list[str]] = {
@@ -57,6 +62,43 @@ def scopes_for_services(services: list[str] | None = None) -> list[str]:
     return result
 
 
+def _is_plaintext_cache(raw: bytes) -> bool:
+    """Return True if `raw` looks like a real MSAL cache (JSON object).
+
+    `msal.token_cache.SerializableTokenCache.serialize()` always emits
+    `json.dumps(self._cache, indent=4)` where `self._cache` starts as `{}` —
+    i.e. the real on-disk format is always a JSON object, never ciphertext
+    (which won't parse as JSON at all) or a bare non-dict value.
+    """
+    try:
+        parsed = json.loads(raw)
+    except (UnicodeDecodeError, json.JSONDecodeError):
+        return False
+    return isinstance(parsed, dict)
+
+
+def _import_legacy_cache(target_cache_path: Path, fernet: Fernet | None) -> None:
+    """Import the pre-per-identity single-account cache into `target_cache_path`, once.
+
+    No-ops if the legacy file doesn't exist, or `target_cache_path` already
+    exists. The old file is deleted after a successful import — not kept as
+    a backup.
+    """
+    if not LEGACY_CACHE_PATH.exists() or target_cache_path.exists():
+        return
+    raw = LEGACY_CACHE_PATH.read_bytes()
+    data = fernet.encrypt(raw) if fernet is not None else raw
+    target_cache_path.parent.mkdir(parents=True, exist_ok=True)
+    target_cache_path.write_bytes(data)
+    target_cache_path.chmod(0o600)
+    LEGACY_CACHE_PATH.unlink()
+    logger.info(
+        "Migrated legacy Microsoft 365 token cache %s to %s (old file removed)",
+        LEGACY_CACHE_PATH,
+        target_cache_path,
+    )
+
+
 class MS365AuthError(Exception):
     """Raised when authentication fails."""
 
@@ -76,6 +118,7 @@ class MS365Auth:
         tenant_id: str = "common",
         services: list[str] | None = None,
         fernet: Fernet | None = None,
+        import_legacy_cache: bool = False,
     ) -> None:
         self._client_id = client_id
         self._tenant_id = tenant_id
@@ -85,6 +128,7 @@ class MS365Auth:
         self._cache: Any = None  # msal.SerializableTokenCache
         self._pending_flow_message: str = ""
         self._fernet = fernet
+        self._import_legacy_cache = import_legacy_cache
 
     def _ensure_app(self) -> None:
         """Lazily initialise the MSAL application."""
@@ -104,20 +148,45 @@ class MS365Auth:
 
     def _load_cache(self) -> None:
         if not self._cache_path.exists():
-            return
+            if self._import_legacy_cache:
+                _import_legacy_cache(self._cache_path, self._fernet)
+            if not self._cache_path.exists():
+                return
         raw = self._cache_path.read_bytes()
         if self._fernet is not None:
             try:
                 raw = self._fernet.decrypt(raw)
             except InvalidToken:
-                logger.warning(
-                    "Token cache at %s could not be decrypted (wrong/rotated key, corrupt "
-                    "file, or a stray unencrypted legacy cache) — treating as no cached "
-                    "token; re-authentication will be required.",
+                if not _is_plaintext_cache(raw):
+                    logger.warning(
+                        "Token cache at %s could not be decrypted (wrong/rotated key or "
+                        "corrupt file) — treating as no cached token; re-authentication "
+                        "will be required.",
+                        self._cache_path,
+                    )
+                    return
+                logger.info(
+                    "Migrating legacy unencrypted token cache to encrypted storage: %s",
                     self._cache_path,
                 )
+                self._cache.deserialize(raw.decode("utf-8"))
+                self._write_cache_bytes(self._fernet.encrypt(raw))
                 return
-        self._cache.deserialize(raw.decode("utf-8"))
+        try:
+            self._cache.deserialize(raw.decode("utf-8"))
+        except (UnicodeDecodeError, json.JSONDecodeError):
+            logger.warning(
+                "Token cache at %s is not readable as plaintext JSON (likely still "
+                "encrypted from a previous run with MS365_TOKEN_ENCRYPTION_KEY set, "
+                "which is now unset) — deleting it; re-authentication will be required.",
+                self._cache_path,
+            )
+            self._cache_path.unlink(missing_ok=True)
+
+    def _write_cache_bytes(self, data: bytes) -> None:
+        self._cache_path.parent.mkdir(parents=True, exist_ok=True)
+        self._cache_path.write_bytes(data)
+        os.chmod(self._cache_path, 0o600)
 
     def _save_cache(self) -> None:
         if not self._cache.has_state_changed:
@@ -125,9 +194,7 @@ class MS365Auth:
         data = self._cache.serialize().encode("utf-8")
         if self._fernet is not None:
             data = self._fernet.encrypt(data)
-        self._cache_path.parent.mkdir(parents=True, exist_ok=True)
-        self._cache_path.write_bytes(data)
-        os.chmod(self._cache_path, 0o600)
+        self._write_cache_bytes(data)
 
     # ── Public API ────────────────────────────────────────────────────────────
 

--- a/src/ms365-mcp/ms365/config.py
+++ b/src/ms365-mcp/ms365/config.py
@@ -58,9 +58,8 @@ class MS365Settings(BaseSettings):  # type: ignore[misc]
     token_cache_dir: Path = Path.home() / ".pincer" / "ms365_mcp"
     token_encryption_key: SecretStr = Field(
         default=SecretStr(""),
-        description="Raw Fernet key (urlsafe-base64, 32 bytes) overriding the on-disk key file.",
+        description="Raw Fernet key (urlsafe-base64, 32 bytes) enabling encryption. Unset = plaintext caches.",
     )
-    token_encryption_key_path: Path = Path.home() / ".pincer" / "ms365_mcp" / "token_encryption.key"
 
     @classmethod
     def settings_customise_sources(
@@ -93,14 +92,6 @@ class MS365Settings(BaseSettings):  # type: ignore[misc]
             raise SystemExit(f"Cannot create/access MS365_TOKEN_CACHE_DIR {path}: {e}") from e
 
         return path
-
-    @field_validator("token_encryption_key_path", mode="before")
-    @classmethod
-    def key_path_str_to_path(cls, value: str | Path) -> Path:
-        try:
-            return Path(value).expanduser()
-        except TypeError as e:
-            raise ValueError(f"Invalid path: {value!r} - {e}") from e
 
 
 @lru_cache(maxsize=1)

--- a/src/ms365-mcp/ms365/config.py
+++ b/src/ms365-mcp/ms365/config.py
@@ -9,7 +9,7 @@ from functools import lru_cache
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
-from pydantic import field_validator
+from pydantic import Field, SecretStr, field_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 from pydantic_settings.sources import EnvSettingsSource, PydanticBaseSettingsSource
 
@@ -56,6 +56,11 @@ class MS365Settings(BaseSettings):  # type: ignore[misc]
     auth_method: str = "device_code"
     services: list[str] = list(_DEFAULT_SERVICES)
     token_cache_dir: Path = Path.home() / ".pincer" / "ms365_mcp"
+    token_encryption_key: SecretStr = Field(
+        default=SecretStr(""),
+        description="Raw Fernet key (urlsafe-base64, 32 bytes) overriding the on-disk key file.",
+    )
+    token_encryption_key_path: Path = Path.home() / ".pincer" / "ms365_mcp" / "token_encryption.key"
 
     @classmethod
     def settings_customise_sources(
@@ -88,6 +93,14 @@ class MS365Settings(BaseSettings):  # type: ignore[misc]
             raise SystemExit(f"Cannot create/access MS365_TOKEN_CACHE_DIR {path}: {e}") from e
 
         return path
+
+    @field_validator("token_encryption_key_path", mode="before")
+    @classmethod
+    def key_path_str_to_path(cls, value: str | Path) -> Path:
+        try:
+            return Path(value).expanduser()
+        except TypeError as e:
+            raise ValueError(f"Invalid path: {value!r} - {e}") from e
 
 
 @lru_cache(maxsize=1)

--- a/src/ms365-mcp/ms365/crypto.py
+++ b/src/ms365-mcp/ms365/crypto.py
@@ -1,41 +1,28 @@
-"""Fernet key management for the per-identity token cache (issue #155)."""
+"""Fernet key resolution for the per-identity token cache (issue #155).
+
+Encryption is opt-in: set MS365_TOKEN_ENCRYPTION_KEY to enable it. When unset,
+token caches are stored in plaintext, matching pre-encryption behavior.
+"""
 
 from __future__ import annotations
 
-import logging
 from typing import TYPE_CHECKING
 
-if TYPE_CHECKING:
-    from cryptography.fernet import Fernet
+from cryptography.fernet import Fernet
 
+if TYPE_CHECKING:
     from ms365.config import MS365Settings
 
-logger = logging.getLogger(__name__)
 
-
-def load_or_generate_fernet(settings: MS365Settings) -> Fernet:
-    """Return the Fernet used to encrypt/decrypt token cache files.
-
-    Precedence: ``MS365_TOKEN_ENCRYPTION_KEY`` (raw key) wins over the on-disk
-    key file entirely — when set, the file is never touched. Otherwise loads
-    ``settings.token_encryption_key_path``, generating one (mode 0600) on
-    first run. Mirrors the load-or-generate pattern used for the MCP OAuth
-    signing key in ``pincer.mcp.auth.tokens.TokenService``.
-    """
-    from cryptography.fernet import Fernet
-
+def resolve_fernet(settings: MS365Settings) -> Fernet | None:
+    """Return the configured Fernet, or None if encryption is disabled."""
     raw_key = settings.token_encryption_key.get_secret_value()
-    if raw_key:
+    if not raw_key:
+        return None
+    try:
         return Fernet(raw_key.encode())
-
-    key_path = settings.token_encryption_key_path
-    if key_path.exists():
-        key_bytes = key_path.read_bytes()
-    else:
-        key_bytes = Fernet.generate_key()
-        key_path.parent.mkdir(parents=True, exist_ok=True)
-        key_path.write_bytes(key_bytes)
-        key_path.chmod(0o600)
-        logger.info("Generated new token encryption key at %s", key_path)
-
-    return Fernet(key_bytes)
+    except ValueError as e:
+        raise ValueError(
+            "MS365_TOKEN_ENCRYPTION_KEY is not a valid Fernet key. Generate one with: "
+            'python -c "from cryptography.fernet import Fernet; print(Fernet.generate_key().decode())"'
+        ) from e

--- a/src/ms365-mcp/ms365/crypto.py
+++ b/src/ms365-mcp/ms365/crypto.py
@@ -1,0 +1,41 @@
+"""Fernet key management for the per-identity token cache (issue #155)."""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from cryptography.fernet import Fernet
+
+    from ms365.config import MS365Settings
+
+logger = logging.getLogger(__name__)
+
+
+def load_or_generate_fernet(settings: MS365Settings) -> Fernet:
+    """Return the Fernet used to encrypt/decrypt token cache files.
+
+    Precedence: ``MS365_TOKEN_ENCRYPTION_KEY`` (raw key) wins over the on-disk
+    key file entirely — when set, the file is never touched. Otherwise loads
+    ``settings.token_encryption_key_path``, generating one (mode 0600) on
+    first run. Mirrors the load-or-generate pattern used for the MCP OAuth
+    signing key in ``pincer.mcp.auth.tokens.TokenService``.
+    """
+    from cryptography.fernet import Fernet
+
+    raw_key = settings.token_encryption_key.get_secret_value()
+    if raw_key:
+        return Fernet(raw_key.encode())
+
+    key_path = settings.token_encryption_key_path
+    if key_path.exists():
+        key_bytes = key_path.read_bytes()
+    else:
+        key_bytes = Fernet.generate_key()
+        key_path.parent.mkdir(parents=True, exist_ok=True)
+        key_path.write_bytes(key_bytes)
+        key_path.chmod(0o600)
+        logger.info("Generated new token encryption key at %s", key_path)
+
+    return Fernet(key_bytes)

--- a/src/ms365-mcp/ms365/identity_session.py
+++ b/src/ms365-mcp/ms365/identity_session.py
@@ -151,6 +151,7 @@ class IdentitySessionManager:
                 cache_path=str(self.cache_path_for(slug)),
                 services=self._services,
                 fernet=self._fernet,
+                import_legacy_cache=(slug == DEFAULT_IDENTITY),
             )
             self._auths[slug] = auth
         return auth

--- a/src/ms365-mcp/ms365/identity_session.py
+++ b/src/ms365-mcp/ms365/identity_session.py
@@ -48,6 +48,7 @@ from typing import TYPE_CHECKING, Any, Literal
 if TYPE_CHECKING:
     from pathlib import Path
 
+    from cryptography.fernet import Fernet
     from fastmcp import Context
 
     from ms365.auth import MS365Auth
@@ -112,11 +113,13 @@ class IdentitySessionManager:
         tenant_id: str,
         cache_dir: Path,
         services: list[str] | None = None,
+        fernet: Fernet | None = None,
     ) -> None:
         self._client_id = client_id
         self._tenant_id = tenant_id
         self._cache_dir = cache_dir
         self._services = services
+        self._fernet = fernet
         self._auths: dict[str, MS365Auth] = {}
         self._clients: dict[str, GraphClient] = {}
         self._pending: dict[str, _PendingFlow] = {}
@@ -147,6 +150,7 @@ class IdentitySessionManager:
                 tenant_id=self._tenant_id,
                 cache_path=str(self.cache_path_for(slug)),
                 services=self._services,
+                fernet=self._fernet,
             )
             self._auths[slug] = auth
         return auth

--- a/src/ms365-mcp/ms365/ms365_server.py
+++ b/src/ms365-mcp/ms365/ms365_server.py
@@ -367,6 +367,7 @@ async def _async_main(args: argparse.Namespace) -> None:
     import sys
 
     from ms365.config import get_settings
+    from ms365.crypto import load_or_generate_fernet
     from ms365.identity_session import IdentitySessionManager
 
     cfg = get_settings()
@@ -383,11 +384,13 @@ async def _async_main(args: argparse.Namespace) -> None:
     # set), not the `--services` tool-exposure filter above — matches today's
     # existing behavior where a narrower `--services` only hides tools, it
     # doesn't shrink the consent scope requested per identity.
+    fernet = load_or_generate_fernet(cfg)
     manager = IdentitySessionManager(
         client_id=cfg.client_id,
         tenant_id=tenant_id,
         cache_dir=cfg.token_cache_dir,
         services=cfg.services,
+        fernet=fernet,
     )
     resolve_client = _make_client_resolver(manager)
 

--- a/src/ms365-mcp/ms365/ms365_server.py
+++ b/src/ms365-mcp/ms365/ms365_server.py
@@ -367,7 +367,7 @@ async def _async_main(args: argparse.Namespace) -> None:
     import sys
 
     from ms365.config import get_settings
-    from ms365.crypto import load_or_generate_fernet
+    from ms365.crypto import resolve_fernet
     from ms365.identity_session import IdentitySessionManager
 
     cfg = get_settings()
@@ -384,7 +384,7 @@ async def _async_main(args: argparse.Namespace) -> None:
     # set), not the `--services` tool-exposure filter above — matches today's
     # existing behavior where a narrower `--services` only hides tools, it
     # doesn't shrink the consent scope requested per identity.
-    fernet = load_or_generate_fernet(cfg)
+    fernet = resolve_fernet(cfg)
     manager = IdentitySessionManager(
         client_id=cfg.client_id,
         tenant_id=tenant_id,

--- a/src/ms365-mcp/ms365/setup_cli.py
+++ b/src/ms365-mcp/ms365/setup_cli.py
@@ -60,7 +60,7 @@ def main() -> None:
 
     from ms365.auth import MS365Auth
     from ms365.config import get_settings
-    from ms365.crypto import load_or_generate_fernet
+    from ms365.crypto import resolve_fernet
     from ms365.identity_session import DEFAULT_IDENTITY
 
     # Pre-seeds the "default" identity slot — the one ms365-mcp-run falls back
@@ -78,8 +78,14 @@ def main() -> None:
         if answer not in ("y", "yes"):
             sys.exit(0)
 
-    fernet = load_or_generate_fernet(settings)
-    auth = MS365Auth(client_id=client_id, tenant_id=tenant_id, cache_path=str(cache_path), fernet=fernet)
+    fernet = resolve_fernet(settings)
+    auth = MS365Auth(
+        client_id=client_id,
+        tenant_id=tenant_id,
+        cache_path=str(cache_path),
+        fernet=fernet,
+        import_legacy_cache=True,
+    )
 
     print(f"Requesting {len(auth.scopes)} permission scope(s)...")
     print("Starting device code authentication...")

--- a/src/ms365-mcp/ms365/setup_cli.py
+++ b/src/ms365-mcp/ms365/setup_cli.py
@@ -60,6 +60,7 @@ def main() -> None:
 
     from ms365.auth import MS365Auth
     from ms365.config import get_settings
+    from ms365.crypto import load_or_generate_fernet
     from ms365.identity_session import DEFAULT_IDENTITY
 
     # Pre-seeds the "default" identity slot — the one ms365-mcp-run falls back
@@ -68,7 +69,8 @@ def main() -> None:
     # the same path IdentitySessionManager reads from lazily on first tool
     # call, so pre-authenticating here just saves that first caller the
     # device-code round trip — it is *not* required for multi-identity use.
-    cache_path = get_settings().token_cache_dir / f"{DEFAULT_IDENTITY}_token_cache.json"
+    settings = get_settings()
+    cache_path = settings.token_cache_dir / f"{DEFAULT_IDENTITY}_token_cache.json"
 
     if cache_path.exists():
         print(f"Token cache already exists: {cache_path}")
@@ -76,7 +78,8 @@ def main() -> None:
         if answer not in ("y", "yes"):
             sys.exit(0)
 
-    auth = MS365Auth(client_id=client_id, tenant_id=tenant_id, cache_path=str(cache_path))
+    fernet = load_or_generate_fernet(settings)
+    auth = MS365Auth(client_id=client_id, tenant_id=tenant_id, cache_path=str(cache_path), fernet=fernet)
 
     print(f"Requesting {len(auth.scopes)} permission scope(s)...")
     print("Starting device code authentication...")

--- a/src/ms365-mcp/pyproject.toml
+++ b/src/ms365-mcp/pyproject.toml
@@ -8,6 +8,7 @@ version = "0.8.0"
 requires-python = ">=3.12"
 dependencies = [
     "msal>=1.28.0",
+    "cryptography>=42",
     # Pinned exactly: fastmcp 3.4.2 restructured its PyPI packaging into a thin
     # wrapper around a separate `fastmcp-slim` distribution, and that install
     # ends up without a usable `fastmcp/__init__.py` (`Context`, `FastMCP`,

--- a/src/ms365-mcp/tests/test_auth.py
+++ b/src/ms365-mcp/tests/test_auth.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
@@ -89,12 +90,13 @@ async def test_get_token_no_cache_raises() -> None:
         auth._cache = None
         auth._pending_flow_message = ""
         auth._fernet = None
+        auth._import_legacy_cache = False
 
         with pytest.raises(MS365AuthError, match="No valid Microsoft 365 token"):
             await auth.get_token()
 
 
-def _bare_auth(fernet: Fernet | None = None) -> MS365Auth:
+def _bare_auth(fernet: Fernet | None = None, import_legacy_cache: bool = False) -> MS365Auth:
     """Build an MS365Auth with private attrs set directly (no msal import needed)."""
     auth = MS365Auth.__new__(MS365Auth)
     auth._client_id = "test-id"
@@ -106,6 +108,7 @@ def _bare_auth(fernet: Fernet | None = None) -> MS365Auth:
     auth._cache.has_state_changed = False
     auth._pending_flow_message = ""
     auth._fernet = fernet
+    auth._import_legacy_cache = import_legacy_cache
     return auth
 
 
@@ -188,10 +191,27 @@ def test_load_cache_wrong_key_treated_as_no_cached_token(tmp_path: Path) -> None
     auth._cache.deserialize.assert_not_called()
 
 
-def test_load_cache_stray_plaintext_legacy_file_treated_as_no_cached_token(tmp_path: Path) -> None:
-    """A leftover unencrypted cache from before Fernet encryption must not crash the server."""
+def test_load_cache_migrates_legacy_plaintext_cache_in_place(tmp_path: Path) -> None:
+    """A leftover unencrypted per-identity cache is encrypted in place, not discarded."""
     cache_path = tmp_path / "tokens.json"
     cache_path.write_text('{"legacy": "plaintext cache"}')
+    fernet = Fernet(Fernet.generate_key())
+
+    auth = _bare_auth(fernet=fernet)
+    auth._cache_path = cache_path
+
+    auth._load_cache()
+
+    auth._cache.deserialize.assert_called_once_with('{"legacy": "plaintext cache"}')
+    raw = cache_path.read_bytes()
+    assert raw != b'{"legacy": "plaintext cache"}'
+    assert fernet.decrypt(raw) == b'{"legacy": "plaintext cache"}'
+    assert oct(cache_path.stat().st_mode)[-3:] == "600"
+
+
+def test_load_cache_non_json_garbage_treated_as_no_cached_token(tmp_path: Path) -> None:
+    cache_path = tmp_path / "tokens.json"
+    cache_path.write_bytes(b"\xff\xfe\x00\x01")
 
     auth = _bare_auth(fernet=Fernet(Fernet.generate_key()))
     auth._cache_path = cache_path
@@ -199,6 +219,120 @@ def test_load_cache_stray_plaintext_legacy_file_treated_as_no_cached_token(tmp_p
     auth._load_cache()
 
     auth._cache.deserialize.assert_not_called()
+
+
+def test_load_cache_non_dict_json_treated_as_no_cached_token(tmp_path: Path) -> None:
+    cache_path = tmp_path / "tokens.json"
+    cache_path.write_text("[1, 2, 3]")
+
+    auth = _bare_auth(fernet=Fernet(Fernet.generate_key()))
+    auth._cache_path = cache_path
+
+    auth._load_cache()
+
+    auth._cache.deserialize.assert_not_called()
+
+
+def test_load_cache_fernet_none_with_stale_encrypted_file_deletes_it(tmp_path: Path) -> None:
+    """Key removed after being used: the now-unreadable file is deleted, forcing re-auth."""
+    cache_path = tmp_path / "tokens.json"
+    cache_path.write_bytes(Fernet(Fernet.generate_key()).encrypt(b'{"real": "cache"}'))
+
+    auth = _bare_auth(fernet=None)
+    auth._cache_path = cache_path
+    # Real MSAL's deserialize() calls json.loads(state) internally and raises on
+    # invalid JSON — the MagicMock cache doesn't do that by default, so simulate it.
+    auth._cache.deserialize.side_effect = json.loads
+
+    auth._load_cache()
+
+    assert not cache_path.exists()
+
+
+def test_import_legacy_cache_plaintext(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    legacy_path = tmp_path / "legacy.json"
+    legacy_path.write_bytes(b'{"legacy": "session"}')
+    monkeypatch.setattr("ms365.auth.LEGACY_CACHE_PATH", legacy_path)
+    target = tmp_path / "default_token_cache.json"
+
+    from ms365.auth import _import_legacy_cache
+
+    _import_legacy_cache(target, None)
+
+    assert target.read_bytes() == b'{"legacy": "session"}'
+    assert not legacy_path.exists()
+
+
+def test_import_legacy_cache_encrypted(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    legacy_path = tmp_path / "legacy.json"
+    legacy_path.write_bytes(b'{"legacy": "session"}')
+    monkeypatch.setattr("ms365.auth.LEGACY_CACHE_PATH", legacy_path)
+    target = tmp_path / "default_token_cache.json"
+    fernet = Fernet(Fernet.generate_key())
+
+    from ms365.auth import _import_legacy_cache
+
+    _import_legacy_cache(target, fernet)
+
+    assert fernet.decrypt(target.read_bytes()) == b'{"legacy": "session"}'
+    assert not legacy_path.exists()
+
+
+def test_import_legacy_cache_skips_when_legacy_file_missing(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr("ms365.auth.LEGACY_CACHE_PATH", tmp_path / "does-not-exist.json")
+    target = tmp_path / "default_token_cache.json"
+
+    from ms365.auth import _import_legacy_cache
+
+    _import_legacy_cache(target, None)
+
+    assert not target.exists()
+
+
+def test_import_legacy_cache_skips_when_target_already_exists(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    legacy_path = tmp_path / "legacy.json"
+    legacy_path.write_bytes(b'{"legacy": "session"}')
+    monkeypatch.setattr("ms365.auth.LEGACY_CACHE_PATH", legacy_path)
+    target = tmp_path / "default_token_cache.json"
+    target.write_bytes(b'{"already": "here"}')
+
+    from ms365.auth import _import_legacy_cache
+
+    _import_legacy_cache(target, None)
+
+    assert target.read_bytes() == b'{"already": "here"}'
+    assert legacy_path.exists()
+
+
+def test_load_cache_imports_legacy_single_cache_when_flag_set(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    legacy_path = tmp_path / "legacy.json"
+    legacy_path.write_bytes(b'{"legacy": "session"}')
+    monkeypatch.setattr("ms365.auth.LEGACY_CACHE_PATH", legacy_path)
+    cache_path = tmp_path / "default_token_cache.json"
+
+    auth = _bare_auth(import_legacy_cache=True)
+    auth._cache_path = cache_path
+
+    auth._load_cache()
+
+    auth._cache.deserialize.assert_called_once_with('{"legacy": "session"}')
+    assert not legacy_path.exists()
+
+
+def test_load_cache_ignores_legacy_cache_when_flag_unset(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    legacy_path = tmp_path / "legacy.json"
+    legacy_path.write_bytes(b'{"legacy": "session"}')
+    monkeypatch.setattr("ms365.auth.LEGACY_CACHE_PATH", legacy_path)
+    cache_path = tmp_path / "default_token_cache.json"
+
+    auth = _bare_auth(import_legacy_cache=False)
+    auth._cache_path = cache_path
+
+    auth._load_cache()
+
+    auth._cache.deserialize.assert_not_called()
+    assert legacy_path.exists()
+    assert not cache_path.exists()
 
 
 def test_complete_device_flow_sync_failure_raises() -> None:
@@ -249,6 +383,7 @@ async def test_get_token_from_cache() -> None:
         auth._cache = mock_cache
         auth._pending_flow_message = ""
         auth._fernet = None
+        auth._import_legacy_cache = False
 
         token = await auth.get_token()
         assert token == "cached-token"

--- a/src/ms365-mcp/tests/test_auth.py
+++ b/src/ms365-mcp/tests/test_auth.py
@@ -6,6 +6,7 @@ from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
+from cryptography.fernet import Fernet
 from ms365.auth import (
     SERVICE_SCOPES,
     MS365Auth,
@@ -87,12 +88,13 @@ async def test_get_token_no_cache_raises() -> None:
         auth._app = None
         auth._cache = None
         auth._pending_flow_message = ""
+        auth._fernet = None
 
         with pytest.raises(MS365AuthError, match="No valid Microsoft 365 token"):
             await auth.get_token()
 
 
-def _bare_auth() -> MS365Auth:
+def _bare_auth(fernet: Fernet | None = None) -> MS365Auth:
     """Build an MS365Auth with private attrs set directly (no msal import needed)."""
     auth = MS365Auth.__new__(MS365Auth)
     auth._client_id = "test-id"
@@ -103,6 +105,7 @@ def _bare_auth() -> MS365Auth:
     auth._cache = MagicMock()
     auth._cache.has_state_changed = False
     auth._pending_flow_message = ""
+    auth._fernet = fernet
     return auth
 
 
@@ -130,7 +133,7 @@ def test_initiate_device_flow_sync_raises_without_user_code() -> None:
         auth.initiate_device_flow_sync()
 
 
-def test_complete_device_flow_sync_success_saves_cache() -> None:
+def test_complete_device_flow_sync_success_saves_cache_unencrypted() -> None:
     auth = _bare_auth()
     auth._cache.has_state_changed = True
     auth._cache.serialize.return_value = '{"fake": "cache"}'
@@ -142,6 +145,60 @@ def test_complete_device_flow_sync_success_saves_cache() -> None:
     auth._cache.serialize.assert_called_once()
     assert auth._cache_path.read_text() == '{"fake": "cache"}'
     auth._cache_path.unlink()
+
+
+def test_complete_device_flow_sync_success_saves_cache_encrypted() -> None:
+    fernet = Fernet(Fernet.generate_key())
+    auth = _bare_auth(fernet=fernet)
+    auth._cache.has_state_changed = True
+    auth._cache.serialize.return_value = '{"fake": "cache"}'
+    auth._app.acquire_token_by_device_flow.return_value = {"access_token": "new-token"}
+
+    result = auth.complete_device_flow_sync({"device_code": "xyz"})
+
+    assert result["access_token"] == "new-token"
+    raw = auth._cache_path.read_bytes()
+    assert raw != b'{"fake": "cache"}'
+    assert fernet.decrypt(raw) == b'{"fake": "cache"}'
+    auth._cache_path.unlink()
+
+
+def test_load_cache_decrypts_with_matching_key(tmp_path: Path) -> None:
+    fernet = Fernet(Fernet.generate_key())
+    cache_path = tmp_path / "tokens.json"
+    cache_path.write_bytes(fernet.encrypt(b'{"real": "cache"}'))
+
+    auth = _bare_auth(fernet=fernet)
+    auth._cache_path = cache_path
+
+    auth._load_cache()
+
+    auth._cache.deserialize.assert_called_once_with('{"real": "cache"}')
+
+
+def test_load_cache_wrong_key_treated_as_no_cached_token(tmp_path: Path) -> None:
+    cache_path = tmp_path / "tokens.json"
+    cache_path.write_bytes(Fernet(Fernet.generate_key()).encrypt(b'{"real": "cache"}'))
+
+    auth = _bare_auth(fernet=Fernet(Fernet.generate_key()))
+    auth._cache_path = cache_path
+
+    auth._load_cache()
+
+    auth._cache.deserialize.assert_not_called()
+
+
+def test_load_cache_stray_plaintext_legacy_file_treated_as_no_cached_token(tmp_path: Path) -> None:
+    """A leftover unencrypted cache from before Fernet encryption must not crash the server."""
+    cache_path = tmp_path / "tokens.json"
+    cache_path.write_text('{"legacy": "plaintext cache"}')
+
+    auth = _bare_auth(fernet=Fernet(Fernet.generate_key()))
+    auth._cache_path = cache_path
+
+    auth._load_cache()
+
+    auth._cache.deserialize.assert_not_called()
 
 
 def test_complete_device_flow_sync_failure_raises() -> None:
@@ -191,6 +248,7 @@ async def test_get_token_from_cache() -> None:
         auth._app = mock_app
         auth._cache = mock_cache
         auth._pending_flow_message = ""
+        auth._fernet = None
 
         token = await auth.get_token()
         assert token == "cached-token"

--- a/src/ms365-mcp/tests/test_config.py
+++ b/src/ms365-mcp/tests/test_config.py
@@ -68,23 +68,6 @@ def test_token_encryption_key_from_env(monkeypatch: pytest.MonkeyPatch) -> None:
     assert cfg.token_encryption_key.get_secret_value() == "some-raw-key"
 
 
-def test_token_encryption_key_path_default() -> None:
-    cfg = MS365Settings()
-    assert cfg.token_encryption_key_path == Path.home() / ".pincer" / "ms365_mcp" / "token_encryption.key"
-
-
-def test_token_encryption_key_path_from_env(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setenv("MS365_TOKEN_ENCRYPTION_KEY_PATH", "/tmp/ms365-key/token.key")
-    cfg = MS365Settings()
-    assert cfg.token_encryption_key_path == Path("/tmp/ms365-key/token.key")
-
-
-def test_token_encryption_key_path_expands_home() -> None:
-    cfg = MS365Settings(token_encryption_key_path="~/.pincer/other-key.key")  # type: ignore[arg-type]
-    assert "~" not in str(cfg.token_encryption_key_path)
-    assert cfg.token_encryption_key_path == Path.home() / ".pincer" / "other-key.key"
-
-
 def test_services_csv_from_env(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("MS365_SERVICES", "email,calendar")
     cfg = MS365Settings()

--- a/src/ms365-mcp/tests/test_config.py
+++ b/src/ms365-mcp/tests/test_config.py
@@ -56,8 +56,9 @@ def test_token_cache_dir_expands_home() -> None:
     assert cfg.token_cache_dir == Path.home() / ".pincer" / "other-ms365"
 
 
-def test_token_encryption_key_default_is_empty_secret() -> None:
-    cfg = MS365Settings()
+def test_token_encryption_key_default_is_empty_secret(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("MS365_TOKEN_ENCRYPTION_KEY", raising=False)
+    cfg = MS365Settings(_env_file=None)  # type: ignore[call-arg]
     assert cfg.token_encryption_key.get_secret_value() == ""
 
 

--- a/src/ms365-mcp/tests/test_config.py
+++ b/src/ms365-mcp/tests/test_config.py
@@ -56,6 +56,34 @@ def test_token_cache_dir_expands_home() -> None:
     assert cfg.token_cache_dir == Path.home() / ".pincer" / "other-ms365"
 
 
+def test_token_encryption_key_default_is_empty_secret() -> None:
+    cfg = MS365Settings()
+    assert cfg.token_encryption_key.get_secret_value() == ""
+
+
+def test_token_encryption_key_from_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("MS365_TOKEN_ENCRYPTION_KEY", "some-raw-key")
+    cfg = MS365Settings()
+    assert cfg.token_encryption_key.get_secret_value() == "some-raw-key"
+
+
+def test_token_encryption_key_path_default() -> None:
+    cfg = MS365Settings()
+    assert cfg.token_encryption_key_path == Path.home() / ".pincer" / "ms365_mcp" / "token_encryption.key"
+
+
+def test_token_encryption_key_path_from_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("MS365_TOKEN_ENCRYPTION_KEY_PATH", "/tmp/ms365-key/token.key")
+    cfg = MS365Settings()
+    assert cfg.token_encryption_key_path == Path("/tmp/ms365-key/token.key")
+
+
+def test_token_encryption_key_path_expands_home() -> None:
+    cfg = MS365Settings(token_encryption_key_path="~/.pincer/other-key.key")  # type: ignore[arg-type]
+    assert "~" not in str(cfg.token_encryption_key_path)
+    assert cfg.token_encryption_key_path == Path.home() / ".pincer" / "other-key.key"
+
+
 def test_services_csv_from_env(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("MS365_SERVICES", "email,calendar")
     cfg = MS365Settings()

--- a/src/ms365-mcp/tests/test_crypto.py
+++ b/src/ms365-mcp/tests/test_crypto.py
@@ -4,14 +4,16 @@ from __future__ import annotations
 
 from pathlib import Path
 
+import pytest
 from cryptography.fernet import Fernet
 from ms365.config import MS365Settings
 from ms365.crypto import load_or_generate_fernet
 
 
-def test_generates_key_file_with_0600_permissions(tmp_path: Path) -> None:
+def test_generates_key_file_with_0600_permissions(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("MS365_TOKEN_ENCRYPTION_KEY", raising=False)
     key_path = tmp_path / "token_encryption.key"
-    settings = MS365Settings(token_encryption_key_path=key_path)  # type: ignore[arg-type]
+    settings = MS365Settings(token_encryption_key_path=key_path, _env_file=None)  # type: ignore[call-arg]
 
     load_or_generate_fernet(settings)
 
@@ -19,12 +21,15 @@ def test_generates_key_file_with_0600_permissions(tmp_path: Path) -> None:
     assert oct(key_path.stat().st_mode)[-3:] == "600"
 
 
-def test_reload_is_idempotent(tmp_path: Path) -> None:
+def test_reload_is_idempotent(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("MS365_TOKEN_ENCRYPTION_KEY", raising=False)
     key_path = tmp_path / "token_encryption.key"
-    settings = MS365Settings(token_encryption_key_path=key_path)  # type: ignore[arg-type]
+    settings = MS365Settings(token_encryption_key_path=key_path, _env_file=None)  # type: ignore[call-arg]
 
     first = load_or_generate_fernet(settings)
-    second = load_or_generate_fernet(MS365Settings(token_encryption_key_path=key_path))  # type: ignore[arg-type]
+    second = load_or_generate_fernet(
+        MS365Settings(token_encryption_key_path=key_path, _env_file=None)  # type: ignore[call-arg]
+    )
 
     token = first.encrypt(b"payload")
     assert second.decrypt(token) == b"payload"

--- a/src/ms365-mcp/tests/test_crypto.py
+++ b/src/ms365-mcp/tests/test_crypto.py
@@ -1,0 +1,44 @@
+"""Tests for the Fernet key load-or-generate logic (issue #155)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from cryptography.fernet import Fernet
+from ms365.config import MS365Settings
+from ms365.crypto import load_or_generate_fernet
+
+
+def test_generates_key_file_with_0600_permissions(tmp_path: Path) -> None:
+    key_path = tmp_path / "token_encryption.key"
+    settings = MS365Settings(token_encryption_key_path=key_path)  # type: ignore[arg-type]
+
+    load_or_generate_fernet(settings)
+
+    assert key_path.exists()
+    assert oct(key_path.stat().st_mode)[-3:] == "600"
+
+
+def test_reload_is_idempotent(tmp_path: Path) -> None:
+    key_path = tmp_path / "token_encryption.key"
+    settings = MS365Settings(token_encryption_key_path=key_path)  # type: ignore[arg-type]
+
+    first = load_or_generate_fernet(settings)
+    second = load_or_generate_fernet(MS365Settings(token_encryption_key_path=key_path))  # type: ignore[arg-type]
+
+    token = first.encrypt(b"payload")
+    assert second.decrypt(token) == b"payload"
+
+
+def test_env_key_overrides_file_and_never_touches_disk(tmp_path: Path) -> None:
+    key_path = tmp_path / "does-not-exist" / "token_encryption.key"
+    raw_key = Fernet.generate_key().decode()
+    settings = MS365Settings(
+        token_encryption_key=raw_key,  # type: ignore[arg-type]
+        token_encryption_key_path=key_path,  # type: ignore[arg-type]
+    )
+
+    fernet = load_or_generate_fernet(settings)
+
+    assert not key_path.exists()
+    assert fernet.decrypt(Fernet(raw_key.encode()).encrypt(b"payload")) == b"payload"

--- a/src/ms365-mcp/tests/test_crypto.py
+++ b/src/ms365-mcp/tests/test_crypto.py
@@ -1,49 +1,32 @@
-"""Tests for the Fernet key load-or-generate logic (issue #155)."""
+"""Tests for Fernet key resolution (issue #155)."""
 
 from __future__ import annotations
-
-from pathlib import Path
 
 import pytest
 from cryptography.fernet import Fernet
 from ms365.config import MS365Settings
-from ms365.crypto import load_or_generate_fernet
+from ms365.crypto import resolve_fernet
 
 
-def test_generates_key_file_with_0600_permissions(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+def test_resolve_fernet_returns_none_when_key_unset(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.delenv("MS365_TOKEN_ENCRYPTION_KEY", raising=False)
-    key_path = tmp_path / "token_encryption.key"
-    settings = MS365Settings(token_encryption_key_path=key_path, _env_file=None)  # type: ignore[call-arg]
+    settings = MS365Settings(_env_file=None)  # type: ignore[call-arg]
 
-    load_or_generate_fernet(settings)
-
-    assert key_path.exists()
-    assert oct(key_path.stat().st_mode)[-3:] == "600"
+    assert resolve_fernet(settings) is None
 
 
-def test_reload_is_idempotent(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.delenv("MS365_TOKEN_ENCRYPTION_KEY", raising=False)
-    key_path = tmp_path / "token_encryption.key"
-    settings = MS365Settings(token_encryption_key_path=key_path, _env_file=None)  # type: ignore[call-arg]
-
-    first = load_or_generate_fernet(settings)
-    second = load_or_generate_fernet(
-        MS365Settings(token_encryption_key_path=key_path, _env_file=None)  # type: ignore[call-arg]
-    )
-
-    token = first.encrypt(b"payload")
-    assert second.decrypt(token) == b"payload"
-
-
-def test_env_key_overrides_file_and_never_touches_disk(tmp_path: Path) -> None:
-    key_path = tmp_path / "does-not-exist" / "token_encryption.key"
+def test_resolve_fernet_returns_working_fernet_when_key_set() -> None:
     raw_key = Fernet.generate_key().decode()
-    settings = MS365Settings(
-        token_encryption_key=raw_key,  # type: ignore[arg-type]
-        token_encryption_key_path=key_path,  # type: ignore[arg-type]
-    )
+    settings = MS365Settings(token_encryption_key=raw_key)  # type: ignore[arg-type]
 
-    fernet = load_or_generate_fernet(settings)
+    fernet = resolve_fernet(settings)
 
-    assert not key_path.exists()
+    assert fernet is not None
     assert fernet.decrypt(Fernet(raw_key.encode()).encrypt(b"payload")) == b"payload"
+
+
+def test_resolve_fernet_raises_clear_error_for_invalid_key() -> None:
+    settings = MS365Settings(token_encryption_key="not-a-valid-hex-key-1234567890")  # type: ignore[arg-type]
+
+    with pytest.raises(ValueError, match="Generate one with"):
+        resolve_fernet(settings)

--- a/src/ms365-mcp/tests/test_identity_session.py
+++ b/src/ms365-mcp/tests/test_identity_session.py
@@ -163,8 +163,8 @@ async def test_get_or_create_shares_one_fernet_across_identities(
     await manager.get_or_create("usr_abc")
     await manager.get_or_create("usr_xyz")
 
-    assert manager._auths["usr_abc"].fernet is fernet  # noqa: SLF001
-    assert manager._auths["usr_xyz"].fernet is fernet  # noqa: SLF001
+    assert cast("Any", manager._auths["usr_abc"]).fernet is fernet  # noqa: SLF001
+    assert cast("Any", manager._auths["usr_xyz"]).fernet is fernet  # noqa: SLF001
     assert cache_paths == [
         str(tmp_path / "usr_abc_token_cache.json"),
         str(tmp_path / "usr_xyz_token_cache.json"),

--- a/src/ms365-mcp/tests/test_identity_session.py
+++ b/src/ms365-mcp/tests/test_identity_session.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import asyncio
 import time
 from pathlib import Path
-from typing import cast
+from typing import Any, cast
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
@@ -40,8 +40,8 @@ def test_sanitize_identity_all_unsafe_falls_back_to_default() -> None:
 # ── IdentitySessionManager ────────────────────────────────────────────────────
 
 
-def _manager(tmp_path: Path) -> IdentitySessionManager:
-    return IdentitySessionManager(client_id="test-client", tenant_id="common", cache_dir=tmp_path)
+def _manager(tmp_path: Path, fernet: Any = None) -> IdentitySessionManager:
+    return IdentitySessionManager(client_id="test-client", tenant_id="common", cache_dir=tmp_path, fernet=fernet)
 
 
 def _patch_cached_auth(monkeypatch: pytest.MonkeyPatch, has_token: bool = True) -> list[str]:
@@ -52,8 +52,11 @@ def _patch_cached_auth(monkeypatch: pytest.MonkeyPatch, has_token: bool = True) 
     constructed_cache_paths: list[str] = []
 
     class _FakeAuth:
-        def __init__(self, client_id: str, tenant_id: str, cache_path: str, services: list[str] | None) -> None:
+        def __init__(
+            self, client_id: str, tenant_id: str, cache_path: str, services: list[str] | None, fernet: Any = None
+        ) -> None:
             constructed_cache_paths.append(cache_path)
+            self.fernet = fernet
 
         def has_cached_token(self) -> bool:
             return has_token
@@ -69,7 +72,9 @@ def _patch_cached_auth(monkeypatch: pytest.MonkeyPatch, has_token: bool = True) 
 class _FakePendingAuth:
     """MS365Auth stand-in with no cached token and a controllable device flow."""
 
-    def __init__(self, client_id: str, tenant_id: str, cache_path: str, services: list[str] | None) -> None:
+    def __init__(
+        self, client_id: str, tenant_id: str, cache_path: str, services: list[str] | None, fernet: Any = None
+    ) -> None:
         self.cache_path = cache_path
         self.completed = asyncio.Event()
         self.should_fail = False
@@ -147,13 +152,35 @@ async def test_get_or_create_missing_identity_uses_default_slot(
 
 
 @pytest.mark.asyncio
+async def test_get_or_create_shares_one_fernet_across_identities(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """One Fernet instance is shared across identities; isolation comes from separate files."""
+    cache_paths = _patch_cached_auth(monkeypatch)
+    fernet = object()
+    manager = _manager(tmp_path, fernet=fernet)
+
+    await manager.get_or_create("usr_abc")
+    await manager.get_or_create("usr_xyz")
+
+    assert manager._auths["usr_abc"].fernet is fernet  # noqa: SLF001
+    assert manager._auths["usr_xyz"].fernet is fernet  # noqa: SLF001
+    assert cache_paths == [
+        str(tmp_path / "usr_abc_token_cache.json"),
+        str(tmp_path / "usr_xyz_token_cache.json"),
+    ]
+
+
+@pytest.mark.asyncio
 async def test_get_or_create_concurrent_calls_construct_auth_once(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     construct_count = 0
 
     class _SlowAuth:
-        def __init__(self, client_id: str, tenant_id: str, cache_path: str, services: list[str] | None) -> None:
+        def __init__(
+            self, client_id: str, tenant_id: str, cache_path: str, services: list[str] | None, fernet: Any = None
+        ) -> None:
             nonlocal construct_count
             construct_count += 1
 
@@ -243,8 +270,10 @@ async def test_get_or_create_retries_fresh_after_background_flow_fails(
 
     instances: list[_FakePendingAuth] = []
 
-    def _make_auth(client_id: str, tenant_id: str, cache_path: str, services: list[str] | None) -> _FakePendingAuth:
-        auth = _FakePendingAuth(client_id, tenant_id, cache_path, services)
+    def _make_auth(
+        client_id: str, tenant_id: str, cache_path: str, services: list[str] | None, fernet: Any = None
+    ) -> _FakePendingAuth:
+        auth = _FakePendingAuth(client_id, tenant_id, cache_path, services, fernet)
         instances.append(auth)
         return auth
 

--- a/src/ms365-mcp/tests/test_identity_session.py
+++ b/src/ms365-mcp/tests/test_identity_session.py
@@ -53,10 +53,17 @@ def _patch_cached_auth(monkeypatch: pytest.MonkeyPatch, has_token: bool = True) 
 
     class _FakeAuth:
         def __init__(
-            self, client_id: str, tenant_id: str, cache_path: str, services: list[str] | None, fernet: Any = None
+            self,
+            client_id: str,
+            tenant_id: str,
+            cache_path: str,
+            services: list[str] | None,
+            fernet: Any = None,
+            import_legacy_cache: bool = False,
         ) -> None:
             constructed_cache_paths.append(cache_path)
             self.fernet = fernet
+            self.import_legacy_cache = import_legacy_cache
 
         def has_cached_token(self) -> bool:
             return has_token
@@ -73,9 +80,16 @@ class _FakePendingAuth:
     """MS365Auth stand-in with no cached token and a controllable device flow."""
 
     def __init__(
-        self, client_id: str, tenant_id: str, cache_path: str, services: list[str] | None, fernet: Any = None
+        self,
+        client_id: str,
+        tenant_id: str,
+        cache_path: str,
+        services: list[str] | None,
+        fernet: Any = None,
+        import_legacy_cache: bool = False,
     ) -> None:
         self.cache_path = cache_path
+        self.import_legacy_cache = import_legacy_cache
         self.completed = asyncio.Event()
         self.should_fail = False
 
@@ -172,6 +186,30 @@ async def test_get_or_create_shares_one_fernet_across_identities(
 
 
 @pytest.mark.asyncio
+async def test_get_or_create_default_identity_passes_import_legacy_cache_true(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _patch_cached_auth(monkeypatch)
+    manager = _manager(tmp_path)
+
+    await manager.get_or_create(None)
+
+    assert cast("Any", manager._auths[DEFAULT_IDENTITY]).import_legacy_cache is True  # noqa: SLF001
+
+
+@pytest.mark.asyncio
+async def test_get_or_create_non_default_identity_passes_import_legacy_cache_false(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _patch_cached_auth(monkeypatch)
+    manager = _manager(tmp_path)
+
+    await manager.get_or_create("usr_abc")
+
+    assert cast("Any", manager._auths["usr_abc"]).import_legacy_cache is False  # noqa: SLF001
+
+
+@pytest.mark.asyncio
 async def test_get_or_create_concurrent_calls_construct_auth_once(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -179,7 +217,13 @@ async def test_get_or_create_concurrent_calls_construct_auth_once(
 
     class _SlowAuth:
         def __init__(
-            self, client_id: str, tenant_id: str, cache_path: str, services: list[str] | None, fernet: Any = None
+            self,
+            client_id: str,
+            tenant_id: str,
+            cache_path: str,
+            services: list[str] | None,
+            fernet: Any = None,
+            import_legacy_cache: bool = False,
         ) -> None:
             nonlocal construct_count
             construct_count += 1
@@ -271,9 +315,14 @@ async def test_get_or_create_retries_fresh_after_background_flow_fails(
     instances: list[_FakePendingAuth] = []
 
     def _make_auth(
-        client_id: str, tenant_id: str, cache_path: str, services: list[str] | None, fernet: Any = None
+        client_id: str,
+        tenant_id: str,
+        cache_path: str,
+        services: list[str] | None,
+        fernet: Any = None,
+        import_legacy_cache: bool = False,
     ) -> _FakePendingAuth:
-        auth = _FakePendingAuth(client_id, tenant_id, cache_path, services, fernet)
+        auth = _FakePendingAuth(client_id, tenant_id, cache_path, services, fernet, import_legacy_cache)
         instances.append(auth)
         return auth
 

--- a/src/ms365-mcp/tests/test_server.py
+++ b/src/ms365-mcp/tests/test_server.py
@@ -6,6 +6,7 @@ import argparse
 from typing import TYPE_CHECKING, Any
 
 import pytest
+from cryptography.fernet import Fernet
 from fastmcp.exceptions import NotFoundError, ToolError
 from ms365 import ms365_server
 
@@ -392,6 +393,11 @@ def test_parse_args_read_only_flag(monkeypatch: pytest.MonkeyPatch) -> None:
 # ── _async_main ───────────────────────────────────────────────────────────────
 
 
+def _set_dummy_encryption_key(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Avoid load_or_generate_fernet() writing a real key file to disk during tests."""
+    monkeypatch.setenv("MS365_TOKEN_ENCRYPTION_KEY", Fernet.generate_key().decode())
+
+
 @pytest.mark.asyncio
 async def test_async_main_exits_without_client_id(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.delenv("MS365_CLIENT_ID", raising=False)
@@ -404,6 +410,7 @@ async def test_async_main_exits_without_client_id(monkeypatch: pytest.MonkeyPatc
 @pytest.mark.asyncio
 async def test_async_main_uses_stdio_transport(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("MS365_CLIENT_ID", "test-client-id")
+    _set_dummy_encryption_key(monkeypatch)
 
     stdio_called: list[bool] = []
 
@@ -421,6 +428,7 @@ async def test_async_main_uses_stdio_transport(monkeypatch: pytest.MonkeyPatch) 
 @pytest.mark.asyncio
 async def test_async_main_uses_http_transport(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("MS365_CLIENT_ID", "test-client-id")
+    _set_dummy_encryption_key(monkeypatch)
 
     http_calls: list[tuple[str, int]] = []
 
@@ -438,6 +446,7 @@ async def test_async_main_uses_http_transport(monkeypatch: pytest.MonkeyPatch) -
 @pytest.mark.asyncio
 async def test_async_main_filters_services(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("MS365_CLIENT_ID", "test-client-id")
+    _set_dummy_encryption_key(monkeypatch)
 
     captured_specs: list[int] = []
 
@@ -469,6 +478,7 @@ async def test_async_main_builds_identity_session_manager_from_settings(monkeypa
 
     monkeypatch.setenv("MS365_CLIENT_ID", "test-client-id")
     monkeypatch.setenv("MS365_SERVICES", "email,calendar,onedrive")
+    _set_dummy_encryption_key(monkeypatch)
 
     constructed: list[dict[str, Any]] = []
 

--- a/src/ms365-mcp/tests/test_server.py
+++ b/src/ms365-mcp/tests/test_server.py
@@ -394,7 +394,11 @@ def test_parse_args_read_only_flag(monkeypatch: pytest.MonkeyPatch) -> None:
 
 
 def _set_dummy_encryption_key(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Avoid load_or_generate_fernet() writing a real key file to disk during tests."""
+    """Keep _async_main tests deterministic regardless of the local .env's MS365_TOKEN_ENCRYPTION_KEY.
+
+    monkeypatch.setenv works here because env vars take priority over .env-file
+    values in MS365Settings' source ordering.
+    """
     monkeypatch.setenv("MS365_TOKEN_ENCRYPTION_KEY", Fernet.generate_key().decode())
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -2357,6 +2357,7 @@ name = "ms365-mcp"
 version = "0.8.0"
 source = { editable = "src/ms365-mcp" }
 dependencies = [
+    { name = "cryptography" },
     { name = "fastmcp" },
     { name = "httpx" },
     { name = "mcp" },
@@ -2382,6 +2383,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
+    { name = "cryptography", specifier = ">=42" },
     { name = "fastmcp", specifier = "==3.2.4" },
     { name = "httpx", specifier = ">=0.27.0" },
     { name = "mcp", specifier = ">=1.24.0" },


### PR DESCRIPTION
## Summary

Closes #155.

`ms365-mcp`'s per-identity token caches (`<MS365_TOKEN_CACHE_DIR>/<identity>_token_cache.json`, introduced in #154) were written in plaintext, protected only by `chmod 0600`. Now that storage is per-identity, a single compromised file leaks one person's mailbox instead of a shared account — this PR encrypts each cache file at rest with a shared Fernet key.

- New `ms365/crypto.py::load_or_generate_fernet()` — generates/loads a Fernet key at `MS365_TOKEN_ENCRYPTION_KEY_PATH` (default `~/.pincer/ms365_mcp/token_encryption.key`, mode `0600`), mirroring the load-or-generate pattern already used for the MCP OAuth signing key in `pincer.mcp.auth.tokens.TokenService`. `MS365_TOKEN_ENCRYPTION_KEY` overrides with a raw key and never touches disk (e.g. for injection from a secrets manager).
- `MS365Auth._load_cache`/`_save_cache` now encrypt/decrypt via a `fernet` param; a cache that fails to decrypt (wrong/rotated key, corruption, or a stray pre-encryption plaintext file) is logged and treated as "no cached token" rather than crashing the server.
- One Fernet instance is shared across all identities on a server — per-identity isolation comes from separate files, not separate keys.
- `cryptography` added as an explicit dependency of `ms365-mcp`'s own `pyproject.toml` (previously only available transitively via the main app's `PyJWT[crypto]`).
- No legacy-cache migration code: the old single-file cache was already fully replaced by the per-identity dir in #154 with no import path, so that transition already forced re-auth. This PR only ensures a stray legacy plaintext file is handled gracefully (doesn't crash).
- Docs (`docs/guides/ms365-mcp.md`, `docs/getting-started/quickstart.md`, `docs/core-components/tools.md`) and `CHANGELOG.md` updated.

## Test plan

- [x] `uv run pytest tests/ src/ms365-mcp/tests/` — 2257 passed (includes new round-trip, wrong-key/corrupted-file, key-generation-permissions, env-override, and two-identity-isolation tests)
- [x] `uv run mypy src/` — no issues
- [x] `uv run ruff check .` — all checks passed
- [x] `uv run ruff format --check .` — all files formatted
- [x] `uv run bandit -r src/pincer -ll -s B101,B104,B310,B608` — no issues
- [x] Manual end-to-end: ran `ms365-mcp-setup` against a real Microsoft account via device-code flow; confirmed `default_token_cache.json` is not readable as plaintext JSON, `token_encryption.key` is mode `0600`, and the cache decrypts correctly on server restart (no re-auth prompt)
- [x] Manual failure-mode check: corrupted/wrong-key cache logs a warning and falls back to requiring re-authentication instead of crashing

### PR Checklist

- [x] Tests pass (pytest)
- [x] Linting passes (ruff check src/ tests/)
- [x] Formatting passes (ruff format --check .)
- [x] Type checking passes (mypy src/)
- [x] Security scan passes (bandit)
- [x] Documentation updated (if behavior changed)
- [x] CHANGELOG.md updated (if user-facing)