### PR TITLE
Add doctr-mcp: FastMCP server wrapping mindee/doctr for OCR

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,10 +10,22 @@ jobs:
       - run: uv sync --all-extras
 
       - name: Run tests with coverage
-        run: uv run pytest --cov=pincer --cov-report=xml tests/ src/ms365-mcp/tests/ src/doctr-mcp/tests
+        run: uv run pytest --cov=pincer --cov-report=xml tests/
+
+      - name: Run ms365-mcp tests
+        run: uv run pytest src/ms365-mcp/tests/
+
+      - name: Run doctr-mcp tests
+        run: uv run pytest src/doctr-mcp/tests
 
       - name: Type check
-        run: uv run mypy src/
+        run: uv run mypy src/ --exclude '(ms365-mcp|doctr-mcp)/tests/'
+
+      - name: Type check ms365-mcp tests
+        run: uv run mypy src/ms365-mcp/tests
+
+      - name: Type check doctr-mcp tests
+        run: uv run mypy src/doctr-mcp/tests
 
       - name: Lint
         run: uv run ruff check .

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
       - run: uv sync --all-extras
 
       - name: Run tests with coverage
-        run: uv run pytest --cov=pincer --cov-report=xml tests/ src/ms365-mcp/tests/
+        run: uv run pytest --cov=pincer --cov-report=xml tests/ src/ms365-mcp/tests/ src/doctr-mcp/tests
 
       - name: Type check
         run: uv run mypy src/

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -110,6 +110,15 @@ services:
       MS365_TENANT_ID: "${PINCER_MS365_TENANT_ID:-common}"
       MS365_TOKEN_CACHE_DIR: "/app/data"
       MS365_TOKEN_ENCRYPTION_KEY: "${PINCER_MS365_TOKEN_ENCRYPTION_KEY}"
+
+  doctr-mcp:
+    extends:
+      file: ./src/doctr-mcp/docker-compose.yml
+      service: doctr-mcp
+    image: pincer/doctr-mcp:latest
+    profiles:
+      - http
+
   pincer-stdio:
     <<: *pincer-base
     container_name: pincer
@@ -149,12 +158,15 @@ services:
         condition: service_healthy
       ms365-mcp:
         condition: service_healthy
+      doctr-mcp:
+        condition: service_healthy
 
 volumes:
   pincer-data:
   memory-data:
   model-cache:
   ms365-data:
+  doctr-model-cache:
 
 networks:
   pincer-net:

--- a/docs/core-components/mcp-servers.md
+++ b/docs/core-components/mcp-servers.md
@@ -447,6 +447,8 @@ Server-specific variables:
 | `doctr-mcp` | `DOCTR_DEFAULT_DET_ARCH` | `db_resnet50` | Default detection architecture when a tool call omits `det_arch` |
 | `doctr-mcp` | `DOCTR_DEFAULT_RECO_ARCH` | `crnn_vgg16_bn` | Default recognition architecture when a tool call omits `reco_arch` |
 | `doctr-mcp` | `DOCTR_CACHE_DIR` | `~/.cache/doctr` | Model weight cache directory (read natively by docTR itself) |
+| `doctr-mcp` | `DOCTR_LOG_TOOL_REQUESTS` | `false` | Log every tool call's request/response payload (truncated) via FastMCP's `LoggingMiddleware` |
+| `doctr-mcp` | `DOCTR_LOG_MAX_PAYLOAD_LENGTH` | `2000` | Max characters of payload logged per call when the above is on |
 | All MCP servers | `OTEL_DSN` | — | OpenTelemetry collector DSN (optional, see [Telemetry](#telemetry)) |
 
 ---

--- a/docs/core-components/mcp-servers.md
+++ b/docs/core-components/mcp-servers.md
@@ -2,8 +2,9 @@
 
 Pincer supports two transports for connecting to MCP servers: **stdio** and
 **streamable-HTTP**. Every bundled MCP server in the workspace (`pomodoro-mcp`,
-`pincer-mcps`, `sqlite-vec-memory-mcp`) implements both. This document explains
-how each transport works, when to use it, and how to configure it in `pincer.toml`.
+`pincer-mcps`, `sqlite-vec-memory-mcp`, `doctr-mcp`) implements both. This document
+explains how each transport works, when to use it, and how to configure it in
+`pincer.toml`.
 
 Related: [MCP Client Guide](../guides/mcp-guide.md) · [MCP Server (outbound)](pincer-mcp-server.md)
 
@@ -369,6 +370,13 @@ name      = "memory"
 transport = "streamable-http"
 url       = "http://memory-server:8002/mcp"
 timeout   = 60
+
+# Heaviest bundled server (torch-based OCR) — HTTP, longer timeout for CPU inference
+[[mcp.servers]]
+name      = "doctr"
+transport = "streamable-http"
+url       = "http://doctr-mcp:8000/mcp"
+timeout   = 120
 ```
 
 ---
@@ -430,6 +438,15 @@ Server-specific variables:
 | `pincer-mcps` (`newsapi`) | `API_KEY` | — | NewsAPI.org API key |
 | `pincer-mcps` (`translate`) | `LIBRETRANSLATE_URL` | — | LibreTranslate instance URL |
 | `pincer-mcps` (`websearch`) | `API_KEY` | — | Tavily API key (optional — falls back to DuckDuckGo if unset) |
+| `doctr-mcp` | `TRANSPORT` | `http` | Overrides the `stdio` default above — heavy-model servers default to HTTP |
+| `doctr-mcp` | `DOCTR_DEVICE` | `cpu` | `cpu` or `cuda` — never auto-detected |
+| `doctr-mcp` | `DOCTR_MAX_WORKERS` | `1` | Max concurrent doctr inferences process-wide |
+| `doctr-mcp` | `DOCTR_TORCH_THREADS` | `0` (= `os.cpu_count()`) | Passed to `torch.set_num_threads()` at startup |
+| `doctr-mcp` | `DOCTR_MAX_CACHED_PREDICTORS` | `4` | Bounded LRU size for the predictor cache |
+| `doctr-mcp` | `DOCTR_MAX_INPUT_MB` | `20` | Reject decoded image/PDF payloads larger than this |
+| `doctr-mcp` | `DOCTR_DEFAULT_DET_ARCH` | `db_resnet50` | Default detection architecture when a tool call omits `det_arch` |
+| `doctr-mcp` | `DOCTR_DEFAULT_RECO_ARCH` | `crnn_vgg16_bn` | Default recognition architecture when a tool call omits `reco_arch` |
+| `doctr-mcp` | `DOCTR_CACHE_DIR` | `~/.cache/doctr` | Model weight cache directory (read natively by docTR itself) |
 | All MCP servers | `OTEL_DSN` | — | OpenTelemetry collector DSN (optional, see [Telemetry](#telemetry)) |
 
 ---
@@ -441,7 +458,7 @@ logs to an [Uptrace](https://uptrace.dev)-compatible OTLP collector. Telemetry i
 **disabled by default** and fully opt-in — no data leaves the process unless you
 set the DSN.
 
-### MCP servers (`pomodoro-mcp`, `pincer-mcps`, `sqlite-vec-memory-mcp`)
+### MCP servers (`pomodoro-mcp`, `pincer-mcps`, `sqlite-vec-memory-mcp`, `doctr-mcp`)
 
 Set `OTEL_DSN` to your collector DSN before starting the server:
 
@@ -471,6 +488,7 @@ Install the telemetry extra for each package:
 pip install "pomodoro-mcp[telemetry]"
 pip install "pincer-mcps[telemetry]"
 pip install "sqlite-vec-memory-mcp[telemetry]"
+pip install "doctr-mcp[telemetry]"
 ```
 
 ### Pincer agent
@@ -500,4 +518,5 @@ pip install "pincer-agent[telemetry]"
 | `pomodoro-mcp` | `OTEL_DSN` | — |
 | `pincer-mcps` (all servers) | `OTEL_DSN` | — |
 | `sqlite-vec-memory-mcp` | `OTEL_DSN` | — |
+| `doctr-mcp` | `OTEL_DSN` | — |
 | Pincer agent | `PINCER_TELEMETRY_DSN` | `telemetry_dsn` |

--- a/pincer.toml
+++ b/pincer.toml
@@ -206,7 +206,7 @@ command = "python"
 args = ["${PINCER_SRC_DIR:-$PWD}/src/doctr-mcp/doctr_mcp/server.py", "--transport", "stdio"]
 env = { DOCTR_DEVICE = "cpu", DOCTR_CACHE_DIR = "${PINCER_DATA_DIR}/doctr_cache" }
 sandbox = true
-approval_required = ["*"]
+approval_required = ["!*"]
 # Predictor construction and model download are lazy (only on first tool call, not
 # at startup), so the default startup_timeout is fine — but per-call inference on
 # CPU is slower than this repo's other bundled servers, hence the longer timeout.

--- a/pincer.toml
+++ b/pincer.toml
@@ -123,6 +123,12 @@ expose_tools = [
 # transport = "streamable-http"
 # url       = "http://websearch-mcp:8000/mcp"
 
+# [[mcp.servers]]
+# name      = "doctr"
+# transport = "streamable-http"
+# url       = "http://doctr-mcp:8000/mcp"
+# timeout   = 120  # CPU-bound OCR inference is slower than a quick API call or embedding lookup
+
 # In app runtime servers using stdio protocol for fast startup (default)
 [[mcp.servers]]
 name = "sqlite_vec_memory"
@@ -192,3 +198,16 @@ approval_required = ["*"]
 # flow before it can speak the MCP protocol — give the user time to sign in.
 # Subsequent runs reuse the cached token and connect in well under a second.
 startup_timeout = 600
+
+[[mcp.servers]]
+name      = "doctr"
+transport = "stdio"
+command = "python"
+args = ["${PINCER_SRC_DIR:-$PWD}/src/doctr-mcp/doctr_mcp/server.py", "--transport", "stdio"]
+env = { DOCTR_DEVICE = "cpu", DOCTR_CACHE_DIR = "${PINCER_DATA_DIR}/doctr_cache" }
+sandbox = true
+approval_required = ["*"]
+# Predictor construction and model download are lazy (only on first tool call, not
+# at startup), so the default startup_timeout is fine — but per-call inference on
+# CPU is slower than this repo's other bundled servers, hence the longer timeout.
+timeout = 120

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -77,6 +77,7 @@ mcp = [
     "pincer-mcps",
     "sqlite-vec-memory-mcp",
     "ms365-mcp",
+    "doctr-mcp",
 ]
 slack = [
     "slack-sdk>=3.27.0",
@@ -147,6 +148,7 @@ extend-ignore = ["N814", "N818"]
 "mcp_servers/**" = ["B008"]
 # Test files use pytest/stdlib imports in annotations at runtime — TC rules don't apply.
 "src/ms365-mcp/tests/**" = ["TC002", "TC003"]
+"src/doctr-mcp/tests/**" = ["TC002", "TC003"]
 "tests/**" = ["TC002", "TC003"]
 
 [tool.mypy]
@@ -206,6 +208,7 @@ members = [
     "src/pomodoro-mcp",
     "src/sqlite-vec-memory-mcp",
     "src/ms365-mcp",
+    "src/doctr-mcp",
 ]
 
 [tool.uv.sources]
@@ -213,3 +216,12 @@ pomodoro-mcp = { workspace = true }
 pincer-mcps = { workspace = true }
 sqlite-vec-memory-mcp = { workspace = true }
 ms365-mcp = { workspace = true }
+doctr-mcp = { workspace = true }
+
+# CPU-only torch/torchvision wheel index for doctr-mcp (src/doctr-mcp/pyproject.toml
+# points its `torch`/`torchvision` sources at this index) — `explicit = true` means it
+# is never used as a default index for anything else in the workspace.
+[[tool.uv.index]]
+name = "pytorch-cpu"
+url = "https://download.pytorch.org/whl/cpu"
+explicit = true

--- a/src/doctr-mcp/Dockerfile
+++ b/src/doctr-mcp/Dockerfile
@@ -1,0 +1,63 @@
+FROM python:3.12-slim
+
+# opencv-python (non-headless) needs libgl1/libglib2.0-0/libsm6/libxext6 on a slim
+# base; ffmpeg covers pypdfium2/opencv's optional codec paths; curl is for the
+# healthcheck. Mirrors doctr's own reference api/Dockerfile's system deps, minus
+# git/make (not needed once installing python-doctr from a released PyPI wheel).
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        libgl1 libglib2.0-0 libsm6 libxext6 ffmpeg curl \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /usr/local/bin/
+
+ENV UV_COMPILE_BYTECODE=1 \
+    UV_LINK_MODE=copy \
+    UV_PROJECT_ENVIRONMENT=/app/.venv
+
+WORKDIR /app
+
+# Install package and deps. This Dockerfile only ever sees this subdirectory as
+# its build context (see docker-compose.yml's `build: .`), so `uv sync` here
+# resolves src/doctr-mcp/pyproject.toml as a standalone project, not as a
+# workspace member — this is why that file carries its own duplicate
+# `[[tool.uv.index]]` block (see the comment there for why).
+COPY pyproject.toml ./
+COPY doctr_mcp ./doctr_mcp
+RUN uv sync --no-cache --no-dev
+
+# Pre-bake a curated set of lightweight architectures into the image so that
+# switching DOCTR_DEFAULT_DET_ARCH/DOCTR_DEFAULT_RECO_ARCH via env var at runtime
+# doesn't trigger a cold Hugging Face download on first use. Override with
+# --build-arg PREBAKE_DET_ARCHS="..." / PREBAKE_RECO_ARCHS="..." (space-separated)
+# to bake a different set.
+ARG PREBAKE_DET_ARCHS="db_resnet50 db_mobilenet_v3_large fast_base"
+ARG PREBAKE_RECO_ARCHS="crnn_vgg16_bn crnn_mobilenet_v3_small"
+ENV DOCTR_CACHE_DIR=/app/models
+# Note: python-doctr==1.0.1 (pinned in pyproject.toml) has no layout-detection or
+# table-structure models — only detection/recognition architectures are baked here.
+RUN mkdir -p /app/models && \
+    for det in $PREBAKE_DET_ARCHS; do \
+        for reco in $PREBAKE_RECO_ARCHS; do \
+            echo "Pre-baking det_arch=$det reco_arch=$reco"; \
+            uv run python -c "from doctr.models import ocr_predictor; ocr_predictor(det_arch='$det', reco_arch='$reco', pretrained=True)"; \
+        done; \
+    done
+
+VOLUME ["/app/models"]
+
+ENV DOCTR_DEVICE=cpu \
+    DOCTR_MAX_WORKERS=1 \
+    DOCTR_DEFAULT_DET_ARCH=db_resnet50 \
+    DOCTR_DEFAULT_RECO_ARCH=crnn_vgg16_bn \
+    TRANSPORT=http \
+    HOST=0.0.0.0 \
+    PORT=8000
+
+EXPOSE 8000
+
+# Cold start includes torch import + baked-model load from disk (slower than
+# sqlite-vec-memory-mcp's ONNX/fastembed equivalent) — hence the longer start_period.
+HEALTHCHECK --interval=30s --timeout=10s --start-period=60s --retries=3 \
+    CMD sh -c 'curl -f http://localhost:${PORT:-8000}/health || exit 1'
+
+CMD ["uv", "run", "doctr-mcp-run"]

--- a/src/doctr-mcp/README.md
+++ b/src/doctr-mcp/README.md
@@ -1,0 +1,121 @@
+# 📄 docTR MCP Server
+
+A [Model Context Protocol](https://modelcontextprotocol.io) server exposing OCR
+(optical character recognition) built on [mindee/doctr](https://github.com/mindee/doctr),
+using [FastMCP](https://github.com/jlowin/fastmcp). Detects and recognizes text in
+images and PDFs, with full block/line/word geometry and key-information extraction
+(KIE). (Layout detection and table-structure extraction are not available in the
+pinned `python-doctr==1.0.1` release — those exist only on doctr's unreleased
+GitHub `main` branch.)
+
+## Tools
+
+| Tool | Description |
+|------|-------------|
+| `ocr_document_text` | Quick plain-text read of an image or PDF — no geometry, the cheap default for "just read this" |
+| `ocr_document` | Full end-to-end OCR: page → block → line → word tree with geometry, confidence, orientation, and language |
+| `detect_text` | Text detection only — boxes/polygons, no recognition |
+| `recognize_text` | Text recognition only, on a batch of pre-cropped word/line images |
+| `extract_key_info` | Key-information extraction (KIE) — predictions grouped by detected class |
+| `list_architectures` | Discover valid `det_arch`/`reco_arch` values |
+
+These are the raw names this server reports over MCP. A connecting client may
+additionally namespace them — e.g. Pincer's own bridge prefixes every tool with its
+configured `pincer.toml` server name, so they appear there as `doctr__ocr_document`,
+`doctr__detect_text`, etc. (see `docs/guides/mcp-guide.md`'s "Tool naming" section).
+
+All document-input tools accept either `image_b64` (base64-encoded image or PDF
+bytes — the portable default, required over the HTTP/Docker deployment) or
+`file_path` (an absolute path, only usable when the server runs via stdio with a
+filesystem shared with the caller) — exactly one of the two per call.
+
+## Quick Start
+
+### With Docker Compose (recommended)
+
+```bash
+docker compose up -d
+```
+
+The server is available at `http://localhost:8000/mcp`. First-time build downloads
+torch and a curated set of pre-baked model weights (see [Notes](#notes) on image
+size) — subsequent starts are fast since weights are cached in the
+`doctr-model-cache` volume.
+
+### Without Docker
+
+```bash
+uv sync
+uv run doctr-mcp-run --transport http
+```
+
+Or over stdio (used by Pincer's own `pincer.toml` example):
+
+```bash
+uv run doctr-mcp-run --transport stdio
+```
+
+### Custom port
+
+```bash
+MCP_PORT=9000 docker compose up -d
+```
+
+## Connect to Claude Code
+
+```bash
+claude mcp add doctr --transport http http://localhost:8000/mcp
+```
+
+## Connect to Claude Desktop
+
+Add to `claude_desktop_config.json`:
+
+```json
+{
+  "mcpServers": {
+    "doctr": {
+      "url": "http://localhost:8000/mcp"
+    }
+  }
+}
+```
+
+## Environment variables
+
+See [docs/core-components/mcp-servers.md](../../docs/core-components/mcp-servers.md)
+for the full reference table shared across all bundled servers. doctr-mcp-specific
+variables:
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `DOCTR_DEVICE` | `cpu` | `cpu` or `cuda` — never auto-detected |
+| `DOCTR_MAX_WORKERS` | `1` | Max concurrent doctr inferences process-wide |
+| `DOCTR_TORCH_THREADS` | `0` (= `os.cpu_count()`) | Passed to `torch.set_num_threads()` at startup |
+| `DOCTR_MAX_CACHED_PREDICTORS` | `4` | Bounded LRU size for the predictor cache |
+| `DOCTR_MAX_INPUT_MB` | `20` | Reject decoded image/PDF payloads larger than this |
+| `DOCTR_DEFAULT_DET_ARCH` | `db_resnet50` | Default detection architecture when a tool call omits `det_arch` |
+| `DOCTR_DEFAULT_RECO_ARCH` | `crnn_vgg16_bn` | Default recognition architecture when a tool call omits `reco_arch` |
+| `DOCTR_CACHE_DIR` | `~/.cache/doctr` | Model weight cache directory (read natively by docTR itself) |
+
+## Notes
+
+- **Architecture names are not restricted** to a fixed enum — `det_arch`/`reco_arch`
+  accept any string docTR itself supports (call
+  `list_architectures` to discover known values). The Docker image pre-bakes
+  a curated set of lightweight architectures at build time (`db_resnet50`,
+  `db_mobilenet_v3_large`, `fast_base` for detection; `crnn_vgg16_bn`,
+  `crnn_mobilenet_v3_small` for recognition) so switching the `DOCTR_DEFAULT_*_ARCH`
+  env vars between them doesn't trigger a cold download — override the baked set
+  with `--build-arg PREBAKE_DET_ARCHS="..."` / `PREBAKE_RECO_ARCHS="..."`.
+- **CPU-only by default.** No GPU passthrough is configured in this repo's Docker
+  setup; set `DOCTR_DEVICE=cuda` only if you know your deployment has one.
+- **This is the heaviest bundled MCP server** — the image includes torch,
+  torchvision, and baked model weights, and is expected to be in the 1.5–3GB range
+  (vs. tens-to-hundreds of MB for `sqlite-vec-memory-mcp`'s ONNX-based image). Build
+  and first pull will take noticeably longer than the other bundled servers.
+- Predictor construction is **lazy** (only on first tool call, not at server
+  startup) and cached per exact parameter set (architectures + thresholds), bounded
+  by `DOCTR_MAX_CACHED_PREDICTORS` with LRU eviction.
+- Multi-page PDFs can be sliced with the optional `page_range` parameter (e.g.
+  `[0, 3]` for the first three pages) to bound response size.

--- a/src/doctr-mcp/docker-compose.yml
+++ b/src/doctr-mcp/docker-compose.yml
@@ -1,0 +1,30 @@
+services:
+  doctr-mcp:
+    build: .
+    restart: unless-stopped
+    environment:
+      TRANSPORT: http
+      HOST: 0.0.0.0
+      PORT: ${MCP_PORT:-8000}
+      DOCTR_DEVICE: cpu
+      DOCTR_MAX_WORKERS: 1
+      DOCTR_TORCH_THREADS: ${DOCTR_TORCH_THREADS:-0}
+      DOCTR_MAX_CACHED_PREDICTORS: ${DOCTR_MAX_CACHED_PREDICTORS:-4}
+      DOCTR_MAX_INPUT_MB: ${DOCTR_MAX_INPUT_MB:-20}
+      DOCTR_DEFAULT_DET_ARCH: ${DOCTR_DEFAULT_DET_ARCH:-db_resnet50}
+      DOCTR_DEFAULT_RECO_ARCH: ${DOCTR_DEFAULT_RECO_ARCH:-crnn_vgg16_bn}
+      # DOCTR_CACHE_DIR is already /app/models inside the image (set at build time).
+      PYTHONUNBUFFERED: 1
+    volumes:
+      - doctr-model-cache:/app/models
+    #ports:
+    #  - "8101:8000"
+    healthcheck:
+      test: ["CMD", "curl", "-sf", "http://localhost:${MCP_PORT:-8000}/health"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 60s
+
+volumes:
+  doctr-model-cache:

--- a/src/doctr-mcp/doctr_mcp/__init__.py
+++ b/src/doctr-mcp/doctr_mcp/__init__.py
@@ -1,0 +1,3 @@
+"""doctr-mcp — FastMCP server exposing mindee/doctr OCR capabilities."""
+
+__version__ = "0.1.0"

--- a/src/doctr-mcp/doctr_mcp/config.py
+++ b/src/doctr-mcp/doctr_mcp/config.py
@@ -48,6 +48,16 @@ class DoctrSettings(BaseSettings):  # type: ignore[misc]
     default_det_arch: str = "db_resnet50"
     default_reco_arch: str = "crnn_vgg16_bn"
 
+    log_tool_requests: bool = False
+    """If True, log every tools/call request and response (tool name, truncated
+    payload, duration) via FastMCP's LoggingMiddleware. Off by default — this is
+    a debugging aid; payloads can contain OCR'd document contents."""
+
+    log_max_payload_length: int = 2000
+    """Max characters of the (JSON-serialized) request/response payload to
+    include per log line when log_tool_requests is on. Prevents a single
+    DOCTR_MAX_INPUT_MB-sized call from writing a multi-megabyte log line."""
+
 
 @lru_cache(maxsize=1)
 def get_settings() -> DoctrSettings:

--- a/src/doctr-mcp/doctr_mcp/config.py
+++ b/src/doctr-mcp/doctr_mcp/config.py
@@ -1,0 +1,95 @@
+"""Configuration for doctr-mcp via environment variables.
+
+Note: docTR itself already reads `DOCTR_CACHE_DIR` directly from the environment
+(see doctr.utils.data) to control where model weights are cached — that variable is
+intentionally *not* duplicated here as a settings field, it's just passed straight
+through to the library.
+"""
+
+from __future__ import annotations
+
+import os
+from functools import lru_cache
+
+from pydantic_settings import BaseSettings, SettingsConfigDict
+
+
+class DoctrSettings(BaseSettings):  # type: ignore[misc]
+    model_config = SettingsConfigDict(
+        env_prefix="DOCTR_",
+        env_ignore_empty=True,
+        extra="ignore",
+        case_sensitive=False,
+    )
+
+    device: str = "cpu"
+    """"cpu" (default) or "cuda". Never auto-detected — this repo's bundled servers
+    are deployed without GPU passthrough by default, so silently preferring CUDA when
+    available would make behavior depend on host hardware."""
+
+    max_workers: int = 1
+    """Max concurrent doctr inference calls process-wide. torch already parallelizes
+    a single call across cores via intra-op threads, so serializing calls tends to
+    beat oversubscribing CPU with N concurrent Python threads."""
+
+    torch_threads: int = 0
+    """Passed to torch.set_num_threads() at startup if > 0. 0 (default) means "let
+    torch_threads_default() pick it, seeded from os.cpu_count()" — set explicitly
+    inside containers with a CPU quota, where torch's own heuristics commonly guess
+    wrong relative to the cgroup limit."""
+
+    max_cached_predictors: int = 4
+    """Bounded LRU size for the predictor cache. Each cached CPU predictor is
+    hundreds of MB resident, so this is not allowed to grow unbounded."""
+
+    max_input_mb: int = 20
+    """Reject decoded (post-base64) image/PDF payloads larger than this many MB."""
+
+    default_det_arch: str = "db_resnet50"
+    default_reco_arch: str = "crnn_vgg16_bn"
+
+
+@lru_cache(maxsize=1)
+def get_settings() -> DoctrSettings:
+    return DoctrSettings()
+
+
+def torch_threads_default() -> int:
+    return os.cpu_count() or 1
+
+
+# Full architecture zoo as of python-doctr 1.0.1, verified against the installed
+# package's real doctr.models.{detection,recognition}.zoo.ARCHS lists (not doctr's
+# GitHub main branch, which has since added layout/table-structure models not
+# present in this release). Tool inputs accept any string here (not a restrictive
+# enum, per product decision) — this list is surfaced only for discovery via the
+# list_architectures tool.
+KNOWN_DET_ARCHS: tuple[str, ...] = (
+    "db_resnet34",
+    "db_resnet50",
+    "db_mobilenet_v3_large",
+    "linknet_resnet18",
+    "linknet_resnet34",
+    "linknet_resnet50",
+    "fast_tiny",
+    "fast_small",
+    "fast_base",
+)
+KNOWN_RECO_ARCHS: tuple[str, ...] = (
+    "crnn_vgg16_bn",
+    "crnn_mobilenet_v3_small",
+    "crnn_mobilenet_v3_large",
+    "sar_resnet31",
+    "master",
+    "vitstr_small",
+    "vitstr_base",
+    "parseq",
+    "viptr_tiny",
+)
+
+# Curated lightweight architectures pre-baked into the Docker image at build time (see
+# Dockerfile's PREBAKE_DET_ARCHS/PREBAKE_RECO_ARCHS build args) so that switching
+# DOCTR_DEFAULT_DET_ARCH/DOCTR_DEFAULT_RECO_ARCH via env var doesn't trigger a cold
+# download on first use.
+PREBAKED_DET_ARCHS: tuple[str, ...] = ("db_resnet50", "db_mobilenet_v3_large", "fast_base")
+PREBAKED_RECO_ARCHS: tuple[str, ...] = ("crnn_vgg16_bn", "crnn_mobilenet_v3_small")

--- a/src/doctr-mcp/doctr_mcp/io_utils.py
+++ b/src/doctr-mcp/doctr_mcp/io_utils.py
@@ -1,0 +1,132 @@
+"""IO helpers: decode tool inputs (base64 bytes or an absolute file path) into
+doctr-ready page arrays, sniff image vs. PDF content, and flatten doctr's geometry
+tuples for JSON serialization.
+
+Mirrors mindee/doctr's own reference app (`api/app/utils.py`): mime-dispatch to
+`DocumentFile.from_images`/`.from_pdf`, and `resolve_geometry`'s box/polygon
+flattening — adapted here for MCP's base64/file_path input instead of FastAPI's
+`UploadFile`.
+"""
+
+from __future__ import annotations
+
+import base64
+import binascii
+from pathlib import Path
+from typing import Any
+
+from doctr_mcp.config import get_settings
+
+_IMAGE_EXTENSIONS = {".jpg", ".jpeg", ".png", ".bmp", ".tif", ".tiff", ".webp"}
+
+
+class InputError(ValueError):
+    """Any problem with caller-supplied image_b64/file_path input — reported back to
+    the MCP caller as a clean tool error, not a stack trace."""
+
+
+def _check_size(data: bytes) -> None:
+    max_bytes = get_settings().max_input_mb * 1024 * 1024
+    if len(data) > max_bytes:
+        raise InputError(
+            f"Input is {len(data) / (1024 * 1024):.1f}MB, exceeding the "
+            f"{get_settings().max_input_mb}MB limit (DOCTR_MAX_INPUT_MB)."
+        )
+
+
+def decode_input(image_b64: str | None, file_path: str | None) -> tuple[bytes, str | None]:
+    """Return (raw_bytes, filename_hint) for exactly one of image_b64 or file_path.
+
+    Mutual-exclusivity is primarily enforced by each tool's pydantic input model
+    (`model_validator`) — this is a defensive second check plus the actual decode.
+    """
+    if image_b64 and file_path:
+        raise InputError("Provide exactly one of image_b64 or file_path, not both.")
+    if not image_b64 and not file_path:
+        raise InputError("Provide one of image_b64 or file_path.")
+
+    if file_path:
+        path = Path(file_path)
+        if not path.is_absolute():
+            raise InputError(f"file_path must be an absolute path, got {file_path!r}.")
+        if not path.is_file():
+            raise InputError(f"file_path does not exist or is not a file: {file_path}")
+        data = path.read_bytes()
+        filename = path.name
+    else:
+        assert image_b64 is not None
+        try:
+            data = base64.b64decode(image_b64, validate=True)
+        except (binascii.Error, ValueError) as e:
+            raise InputError(f"image_b64 is not valid base64: {e}") from e
+        filename = None
+
+    _check_size(data)
+    return data, filename
+
+
+def _sniff_kind(data: bytes, filename: str | None) -> str:
+    if data[:5] == b"%PDF-":
+        return "pdf"
+    if filename:
+        ext = Path(filename).suffix.lower()
+        if ext == ".pdf":
+            return "pdf"
+        if ext in _IMAGE_EXTENSIONS:
+            return "image"
+    try:
+        from io import BytesIO
+
+        from PIL import Image
+
+        with Image.open(BytesIO(data)) as img:
+            img.verify()
+        return "image"
+    except Exception:
+        hint = f" for {filename!r}" if filename else ""
+        raise InputError(
+            f"Unsupported or unrecognized file content{hint}. Supported formats: PNG, JPEG, BMP, TIFF, WEBP, PDF."
+        ) from None
+
+
+def documents_from_bytes(
+    data: bytes,
+    filename: str | None,
+    page_range: tuple[int, int] | None = None,
+) -> tuple[list[Any], list[str]]:
+    """Build (page_arrays, page_filenames) ready for a doctr predictor call.
+
+    For PDFs, `page_range` is an optional (start, end) slice (end-exclusive) applied
+    before running any model — a full multi-hundred-page PDF would otherwise blow
+    past any reasonable tool-result size.
+    """
+    from doctr.io import DocumentFile
+
+    kind = _sniff_kind(data, filename)
+    label = filename or ("document.pdf" if kind == "pdf" else "image")
+
+    if kind == "pdf":
+        pages = list(DocumentFile.from_pdf(data))
+        if page_range is not None:
+            start, end = page_range
+            pages = pages[start:end]
+        if not pages:
+            raise InputError("page_range selected zero pages.")
+        return pages, [label] * len(pages)
+
+    pages = list(DocumentFile.from_images([data]))
+    return pages, [label]
+
+
+def resolve_geometry(geom: Any) -> tuple[float, ...]:
+    """Flatten doctr's polygon/box geometry (tuple-of-(x,y)-points) into a flat
+    tuple of floats — never hand raw numpy arrays or nested tuples across the MCP
+    boundary. Mirrors doctr's own `api/app/utils.resolve_geometry`: a 4-point
+    polygon flattens to 8 floats, a 2-point (xmin,ymin)/(xmax,ymax) box to 4."""
+    if len(geom) == 4:
+        return (*geom[0], *geom[1], *geom[2], *geom[3])
+    return (*geom[0], *geom[1])
+
+
+def round_confidence(value: float) -> float:
+    return round(float(value), 2)

--- a/src/doctr-mcp/doctr_mcp/predictors.py
+++ b/src/doctr-mcp/doctr_mcp/predictors.py
@@ -1,0 +1,206 @@
+"""Lazy singleton doctr predictor cache with bounded LRU eviction and per-key locking.
+
+docTR's own reference implementation (mindee/doctr `api/app/vision.py`) mutates
+`predictor.det_predictor.model.postprocessor.bin_thresh`/`box_thresh` as instance
+attributes *after* construction. That means the cache key here must include those
+thresholds (and every other parameter that affects predictor behavior) — keying only
+on architecture names would let two concurrent calls with different thresholds race
+on a shared predictor instance.
+
+Note: the pinned `python-doctr==1.0.1` release does not support layout detection,
+table structure, or `disable_page_orientation`/`disable_crop_orientation` — those
+exist only on doctr's unreleased GitHub `main` branch (verified by introspecting the
+installed package's real signatures). Do not reintroduce them without also bumping
+the pinned version and re-verifying against the actually-installed API surface.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import threading
+from collections import OrderedDict
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any
+
+from doctr_mcp.config import get_settings
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+logger = logging.getLogger(__name__)
+
+Task = str  # "detection" | "recognition" | "ocr" | "kie"
+
+
+@dataclass(frozen=True)
+class PredictorParams:
+    task: Task
+    det_arch: str = "db_resnet50"
+    reco_arch: str = "crnn_vgg16_bn"
+    assume_straight_pages: bool = True
+    preserve_aspect_ratio: bool = True
+    symmetric_pad: bool = True
+    detect_orientation: bool = False
+    straighten_pages: bool = False
+    detect_language: bool = False
+    det_bs: int = 2
+    reco_bs: int = 128
+    bin_thresh: float = 0.1
+    box_thresh: float = 0.1
+    # OCR-only (ignored for task == "kie"/"detection"/"recognition" — kie_predictor's
+    # signature doesn't accept them, and detection/recognition slice a sub-predictor
+    # out of a full ocr_predictor build anyway, same trick doctr's own
+    # api/app/vision.py uses). Defaults match doctr.models.builder.DocumentBuilder's
+    # own defaults in the pinned 1.0.1 release.
+    resolve_lines: bool = True
+    resolve_blocks: bool = False
+    paragraph_break: float = 0.035
+
+    def cache_key(self) -> tuple[tuple[str, Any], ...]:
+        return tuple(sorted(self.__dict__.items()))
+
+
+class _BoundedPredictorCache:
+    """A plain-dict-backed LRU cache guarded by a thread lock (get/set are cheap and
+    synchronous — the expensive part, building a predictor, happens outside this
+    lock, guarded instead by the per-key asyncio.Lock in `get_predictor`)."""
+
+    def __init__(self, maxsize: int) -> None:
+        self._maxsize = maxsize
+        self._data: OrderedDict[tuple[tuple[str, Any], ...], Any] = OrderedDict()
+        self._guard = threading.Lock()
+
+    def get(self, key: tuple[tuple[str, Any], ...]) -> Any | None:
+        with self._guard:
+            if key not in self._data:
+                return None
+            self._data.move_to_end(key)
+            return self._data[key]
+
+    def set(self, key: tuple[tuple[str, Any], ...], value: Any) -> None:
+        with self._guard:
+            self._data[key] = value
+            self._data.move_to_end(key)
+            while len(self._data) > self._maxsize:
+                evicted_key, _ = self._data.popitem(last=False)
+                logger.info("Evicted cached predictor for key=%s", evicted_key)
+
+    def __len__(self) -> int:
+        with self._guard:
+            return len(self._data)
+
+
+_cache: _BoundedPredictorCache | None = None
+_locks: dict[tuple[tuple[str, Any], ...], asyncio.Lock] = {}
+_locks_guard = threading.Lock()
+
+
+def _get_cache() -> _BoundedPredictorCache:
+    global _cache
+    if _cache is None:
+        _cache = _BoundedPredictorCache(get_settings().max_cached_predictors)
+    return _cache
+
+
+def _get_lock(key: tuple[tuple[str, Any], ...]) -> asyncio.Lock:
+    with _locks_guard:
+        lock = _locks.get(key)
+        if lock is None:
+            lock = asyncio.Lock()
+            _locks[key] = lock
+        return lock
+
+
+def reset_state() -> None:
+    """Test-only: clear the module-level cache/lock singletons between test cases."""
+    global _cache
+    _cache = None
+    _locks.clear()
+
+
+def _build_predictor(params: PredictorParams) -> Any:
+    import torch
+    from doctr.models import kie_predictor, ocr_predictor
+
+    kwargs: dict[str, Any] = {
+        "det_arch": params.det_arch,
+        "reco_arch": params.reco_arch,
+        "pretrained": True,
+        "assume_straight_pages": params.assume_straight_pages,
+        "preserve_aspect_ratio": params.preserve_aspect_ratio,
+        "symmetric_pad": params.symmetric_pad,
+        "detect_orientation": params.detect_orientation,
+        "straighten_pages": params.straighten_pages,
+        "detect_language": params.detect_language,
+        "det_bs": params.det_bs,
+        "reco_bs": params.reco_bs,
+    }
+
+    predictor: Any
+    if params.task == "kie":
+        # kie_predictor's signature has no resolve_lines/resolve_blocks/
+        # paragraph_break — KIE output is per-class predictions, not a block/line
+        # tree, and passing these would not be a recognized kwarg.
+        predictor = kie_predictor(**kwargs)
+    else:
+        predictor = ocr_predictor(
+            **kwargs,
+            resolve_lines=params.resolve_lines,
+            resolve_blocks=params.resolve_blocks,
+            paragraph_break=params.paragraph_break,
+        )
+
+    det_model: Any = predictor.det_predictor.model
+    det_model.postprocessor.bin_thresh = params.bin_thresh
+    det_model.postprocessor.box_thresh = params.box_thresh
+
+    device = torch.device("cuda" if get_settings().device == "cuda" else "cpu")
+    predictor = predictor.to(device)
+
+    if params.task == "detection":
+        return predictor.det_predictor
+    if params.task == "recognition":
+        return predictor.reco_predictor
+    return predictor
+
+
+# Swappable in tests so no real torch/doctr import is ever exercised.
+predictor_builder: Callable[[PredictorParams], Any] = _build_predictor
+
+_inference_semaphore: asyncio.Semaphore | None = None
+
+
+def _get_inference_semaphore() -> asyncio.Semaphore:
+    global _inference_semaphore
+    if _inference_semaphore is None:
+        _inference_semaphore = asyncio.Semaphore(get_settings().max_workers)
+    return _inference_semaphore
+
+
+async def get_predictor(params: PredictorParams) -> Any:
+    """Return a cached predictor for these params, building it if necessary.
+
+    Concurrent calls sharing the same params share one asyncio.Lock, so the predictor
+    is built (and its thresholds mutated) exactly once, and no caller can observe a
+    partially-configured predictor mid-mutation.
+    """
+    key = params.cache_key()
+    cache = _get_cache()
+    lock = _get_lock(key)
+    async with lock:
+        predictor = cache.get(key)
+        if predictor is None:
+            predictor = await asyncio.to_thread(predictor_builder, params)
+            cache.set(key, predictor)
+        return predictor
+
+
+async def run_predictor(predictor: Any, documents: list[Any]) -> Any:
+    """Run predictor inference off the event loop, capped by DOCTR_MAX_WORKERS
+    concurrent inferences process-wide (torch already parallelizes a single call
+    across cores via intra-op threads — serializing calls tends to beat letting N
+    Python threads oversubscribe CPU)."""
+    semaphore = _get_inference_semaphore()
+    async with semaphore:
+        return await asyncio.to_thread(predictor, documents)

--- a/src/doctr-mcp/doctr_mcp/schemas.py
+++ b/src/doctr-mcp/doctr_mcp/schemas.py
@@ -1,0 +1,284 @@
+"""Pydantic input/output models for doctr-mcp's tools.
+
+Convention (matching src/pincer-mcps/openweathermap_server.py): one input model per
+tool, `extra="forbid"`, `Field(description=...)` on every field, passed to the tool
+as a single `params` argument.
+
+Architecture names (`det_arch`/`reco_arch`) are plain strings with sensible
+defaults, not a restrictive `Literal[...]` enum — full customization is allowed;
+call `list_architectures` to discover valid names.
+
+Note: layout detection, table structure, and `disable_page_orientation`/
+`disable_crop_orientation` are not supported — those exist only on doctr's
+unreleased GitHub `main` branch, not in the pinned `python-doctr==1.0.1` release
+(confirmed by introspecting the installed package's real signatures).
+"""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+from doctr_mcp.config import get_settings
+
+# ---------------------------------------------------------------------------
+# Shared input pieces
+# ---------------------------------------------------------------------------
+
+
+class ImageSource(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    image_b64: str | None = Field(
+        default=None,
+        description=(
+            "Base64-encoded image or PDF bytes. The portable default — required when "
+            "doctr-mcp is deployed over HTTP/Docker, since there is no shared "
+            "filesystem with the caller in that case."
+        ),
+    )
+    file_path: str | None = Field(
+        default=None,
+        description=(
+            "Absolute path to a file on disk. Only usable when doctr-mcp runs via "
+            "stdio with a filesystem shared with the caller (e.g. Pincer's "
+            "PINCER_DATA_DIR) — not usable against the default HTTP/Docker "
+            "deployment unless a volume is explicitly shared."
+        ),
+    )
+    filename: str | None = Field(
+        default=None,
+        description="Optional filename hint (e.g. 'scan.pdf') to disambiguate format when image_b64 is given.",
+    )
+
+    @model_validator(mode="after")
+    def _check_exclusive(self) -> ImageSource:
+        if bool(self.image_b64) == bool(self.file_path):
+            raise ValueError("Provide exactly one of image_b64 or file_path.")
+        return self
+
+
+def _page_range_field() -> tuple[int, int] | None:
+    return Field(
+        default=None,
+        description=(
+            "Optional [start, end) page slice for multi-page PDFs, e.g. [0, 3] for "
+            "the first three pages. Ignored for single images. Applied before "
+            "running any model, to bound response size for large PDFs."
+        ),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Detection
+# ---------------------------------------------------------------------------
+
+
+class DetectionInput(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    source: ImageSource
+    page_range: tuple[int, int] | None = _page_range_field()
+    det_arch: str = Field(
+        default_factory=lambda: get_settings().default_det_arch,
+        description="Detection architecture name, e.g. 'db_resnet50'. See list_architectures.",
+    )
+    assume_straight_pages: bool = Field(default=True, description="If True, fit straight boxes to the page.")
+    preserve_aspect_ratio: bool = Field(
+        default=True, description="Pad the input to preserve aspect ratio before detection."
+    )
+    symmetric_pad: bool = Field(default=True, description="Pad the image symmetrically instead of bottom-right only.")
+    det_bs: int = Field(default=2, ge=1, description="Detection batch size.")
+    bin_thresh: float = Field(
+        default=0.1, ge=0.0, le=1.0, description="Binarization threshold for the detection postprocessor."
+    )
+    box_thresh: float = Field(
+        default=0.1, ge=0.0, le=1.0, description="Box confidence threshold for the detection postprocessor."
+    )
+
+
+class DetectionBox(BaseModel):
+    geometry: tuple[float, ...] = Field(description="Flattened box/polygon coordinates, normalized to [0, 1].")
+    confidence: float | None = Field(default=None, description="Confidence score, if the architecture reports one.")
+
+
+class DetectionResult(BaseModel):
+    name: str
+    boxes: list[DetectionBox]
+
+
+class DetectionOutput(BaseModel):
+    results: list[DetectionResult]
+
+
+# ---------------------------------------------------------------------------
+# Recognition
+# ---------------------------------------------------------------------------
+
+
+class RecognitionInput(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    images: list[ImageSource] = Field(description="Pre-cropped word/line images to recognize (one result per image).")
+    reco_arch: str = Field(
+        default_factory=lambda: get_settings().default_reco_arch,
+        description="Recognition architecture name, e.g. 'crnn_vgg16_bn'. See list_architectures.",
+    )
+    reco_bs: int = Field(default=128, ge=1, description="Recognition batch size.")
+
+
+class RecognitionItem(BaseModel):
+    text: str
+    confidence: float
+
+
+class RecognitionOutput(BaseModel):
+    results: list[RecognitionItem]
+
+
+# ---------------------------------------------------------------------------
+# OCR (full tree + text convenience)
+# ---------------------------------------------------------------------------
+
+
+class OcrDocumentInput(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    source: ImageSource
+    page_range: tuple[int, int] | None = _page_range_field()
+    det_arch: str = Field(default_factory=lambda: get_settings().default_det_arch)
+    reco_arch: str = Field(default_factory=lambda: get_settings().default_reco_arch)
+    assume_straight_pages: bool = Field(default=True)
+    preserve_aspect_ratio: bool = Field(default=True)
+    symmetric_pad: bool = Field(default=True)
+    detect_orientation: bool = Field(default=False, description="Detect page orientation (0/90/180/270).")
+    straighten_pages: bool = Field(default=False, description="Rotate pages upright before running detection.")
+    detect_language: bool = Field(default=False, description="Detect the dominant page language.")
+    det_bs: int = Field(default=2, ge=1)
+    reco_bs: int = Field(default=128, ge=1)
+    bin_thresh: float = Field(default=0.1, ge=0.0, le=1.0)
+    box_thresh: float = Field(default=0.1, ge=0.0, le=1.0)
+    resolve_lines: bool = Field(default=True, description="Group words into lines.")
+    resolve_blocks: bool = Field(default=False, description="Group lines into blocks.")
+    paragraph_break: float = Field(
+        default=0.035,
+        description="Vertical-gap threshold (as a fraction of page height) used to split paragraphs/blocks.",
+    )
+
+
+class OcrDocumentTextInput(OcrDocumentInput):
+    """Same predictor/params as ocr_document (so both tools share the same
+    cached predictor for identical params) — only the output shape differs."""
+
+
+class CropOrientation(BaseModel):
+    value: int
+    confidence: float | None = None
+
+
+class OcrWord(BaseModel):
+    value: str
+    geometry: tuple[float, ...]
+    objectness_score: float
+    confidence: float
+    crop_orientation: CropOrientation
+
+
+class OcrLine(BaseModel):
+    geometry: tuple[float, ...]
+    objectness_score: float
+    words: list[OcrWord]
+
+
+class OcrBlock(BaseModel):
+    geometry: tuple[float, ...]
+    objectness_score: float
+    lines: list[OcrLine]
+
+
+class OcrPageValue(BaseModel):
+    value: float | None = None
+    confidence: float | None = None
+
+
+class OcrLanguage(BaseModel):
+    value: str | None = None
+    confidence: float | None = None
+
+
+class OcrPage(BaseModel):
+    name: str
+    orientation: OcrPageValue
+    language: OcrLanguage
+    dimensions: tuple[int, int]
+    blocks: list[OcrBlock]
+
+
+class OcrDocumentOutput(BaseModel):
+    pages: list[OcrPage]
+
+
+class OcrDocumentTextOutput(BaseModel):
+    pages: list[str] = Field(description="Concatenated text per page, in reading order.")
+    text: str = Field(description="All pages concatenated, separated by blank lines.")
+
+
+# ---------------------------------------------------------------------------
+# KIE
+# ---------------------------------------------------------------------------
+
+
+class KieInput(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    source: ImageSource
+    page_range: tuple[int, int] | None = _page_range_field()
+    det_arch: str = Field(default_factory=lambda: get_settings().default_det_arch)
+    reco_arch: str = Field(default_factory=lambda: get_settings().default_reco_arch)
+    assume_straight_pages: bool = Field(default=True)
+    preserve_aspect_ratio: bool = Field(default=True)
+    symmetric_pad: bool = Field(default=True)
+    detect_language: bool = Field(default=False)
+    det_bs: int = Field(default=2, ge=1)
+    reco_bs: int = Field(default=128, ge=1)
+    bin_thresh: float = Field(default=0.1, ge=0.0, le=1.0)
+    box_thresh: float = Field(default=0.1, ge=0.0, le=1.0)
+
+
+class KieItem(BaseModel):
+    value: str
+    geometry: tuple[float, ...]
+    objectness_score: float
+    confidence: float
+    crop_orientation: CropOrientation
+
+
+class KieClassPredictions(BaseModel):
+    class_name: str
+    items: list[KieItem]
+
+
+class KiePage(BaseModel):
+    name: str
+    orientation: OcrPageValue
+    language: OcrLanguage
+    dimensions: tuple[int, int]
+    predictions: list[KieClassPredictions]
+
+
+class KieOutput(BaseModel):
+    pages: list[KiePage]
+
+
+# ---------------------------------------------------------------------------
+# Meta / discovery
+# ---------------------------------------------------------------------------
+
+
+class ListArchitecturesInput(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+
+class ListArchitecturesOutput(BaseModel):
+    detection: list[str]
+    recognition: list[str]
+    defaults: dict[str, str]

--- a/src/doctr-mcp/doctr_mcp/server.py
+++ b/src/doctr-mcp/doctr_mcp/server.py
@@ -53,6 +53,8 @@ mcp = FastMCP(
         "Use detect_text / recognize_text for the individual detection "
         "or recognition stages, extract_key_info for key-information extraction, "
         "and list_architectures to discover valid det_arch/reco_arch values. "
+        "Do not attempt to read PDF or image files yourself with file_read, shell_exec, "
+        "or python_exec — hand them to this server's OCR tools instead. "
         "(Tool names may appear with an additional server-name prefix depending on "
         "how the connecting MCP client namespaces tools.)"
     ),
@@ -63,6 +65,19 @@ register_recognition_tools(mcp)
 register_ocr_tools(mcp)
 register_kie_tools(mcp)
 register_meta_tools(mcp)
+
+_settings = get_settings()
+if _settings.log_tool_requests:
+    from fastmcp.server.middleware.logging import LoggingMiddleware
+
+    mcp.add_middleware(
+        LoggingMiddleware(
+            logger=logging.getLogger("doctr_mcp.requests"),
+            include_payloads=True,
+            max_payload_length=_settings.log_max_payload_length,
+            methods=["tools/call"],
+        )
+    )
 
 
 @mcp.custom_route("/", methods=["GET"])

--- a/src/doctr-mcp/doctr_mcp/server.py
+++ b/src/doctr-mcp/doctr_mcp/server.py
@@ -1,0 +1,130 @@
+"""doctr-mcp — FastMCP server exposing mindee/doctr OCR capabilities.
+
+Transports:
+    stdio:  python -m doctr_mcp.server --transport stdio
+    HTTP (default for this server — see docs/core-components/mcp-servers.md):
+            python -m doctr_mcp.server --transport http [--host 0.0.0.0] [--port 8000]
+        MCP endpoint → http://localhost:8000/mcp
+
+Environment:
+    See doctr_mcp.config.DoctrSettings for DOCTR_* tuning variables, plus the
+    standard TRANSPORT / HOST / PORT variables shared by all bundled MCP servers.
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import os
+from typing import TYPE_CHECKING
+
+import torch
+import uvicorn
+from fastapi.responses import JSONResponse
+from fastmcp import FastMCP
+from starlette.middleware.cors import CORSMiddleware
+
+from doctr_mcp import __version__
+from doctr_mcp.config import get_settings, torch_threads_default
+from doctr_mcp.tools_detection import register_detection_tools
+from doctr_mcp.tools_kie import register_kie_tools
+from doctr_mcp.tools_meta import register_meta_tools
+from doctr_mcp.tools_ocr import register_ocr_tools
+from doctr_mcp.tools_recognition import register_recognition_tools
+
+if TYPE_CHECKING:
+    from starlette.requests import Request
+
+LOG_LEVEL = os.environ.get("LOG_LEVEL", "INFO")
+
+logging.basicConfig(
+    level=getattr(logging, LOG_LEVEL, logging.INFO),
+    format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
+)
+logger = logging.getLogger(__name__)
+
+mcp = FastMCP(
+    name="doctr_mcp",
+    instructions=(
+        "OCR MCP server built on mindee/doctr. "
+        "Use ocr_document_text for a quick plain-text read of an image or PDF. "
+        "Use ocr_document for the full block/line/word tree with geometry, "
+        "orientation, and language detection. "
+        "Use detect_text / recognize_text for the individual detection "
+        "or recognition stages, extract_key_info for key-information extraction, "
+        "and list_architectures to discover valid det_arch/reco_arch values. "
+        "(Tool names may appear with an additional server-name prefix depending on "
+        "how the connecting MCP client namespaces tools.)"
+    ),
+)
+
+register_detection_tools(mcp)
+register_recognition_tools(mcp)
+register_ocr_tools(mcp)
+register_kie_tools(mcp)
+register_meta_tools(mcp)
+
+
+@mcp.custom_route("/", methods=["GET"])
+@mcp.custom_route("/health", methods=["GET"])
+async def health_check(request: Request) -> JSONResponse:
+    return JSONResponse({"status": "healthy", "service": "doctr-mcp", "version": __version__})
+
+
+def _configure_torch() -> None:
+    settings = get_settings()
+    threads = settings.torch_threads or torch_threads_default()
+    torch.set_num_threads(threads)
+    logger.info("torch.set_num_threads(%d)", threads)
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="doctr-mcp OCR server (fastmcp)")
+    parser.add_argument(
+        "--transport",
+        choices=["http", "stdio"],
+        default=os.environ.get("TRANSPORT", "http"),
+        help="Transport: 'http' (streamable HTTP, default for this server) or 'stdio'",
+    )
+    parser.add_argument(
+        "--host",
+        default=os.environ.get("HOST", "0.0.0.0"),
+        help="Bind host for HTTP transport (default: 0.0.0.0)",
+    )
+    parser.add_argument(
+        "--port",
+        type=int,
+        default=os.environ.get("PORT", 8000),
+        help="Bind port for HTTP transport (default: 8000)",
+    )
+    return parser.parse_args()
+
+
+def main() -> None:
+    try:
+        from pincer_telemetry import init as _init_telemetry
+
+        _init_telemetry(project_name="doctr_mcp", version=__version__)
+        logger.info("Telemetry init success")
+    except ImportError:
+        logger.warning(
+            "OTEL_DSN is set but pincer-telemetry is not installed — "
+            'skipping. Install with: pip install "doctr-mcp[telemetry]"'
+        )
+    except Exception as _tel_err:
+        logger.error("Telemetry init failed (non-fatal): %s", _tel_err)
+
+    _configure_torch()
+    args = _parse_args()
+
+    if args.transport == "http":
+        logger.info("Starting doctr_mcp · HTTP transport · %s:%s/mcp", args.host, args.port)
+        app = mcp.http_app()
+        cors_app = CORSMiddleware(app=app, allow_origins=["*"], allow_methods=["*"], allow_headers=["*"])
+        uvicorn.run(cors_app, host=args.host, port=args.port)
+    else:
+        mcp.run(transport="stdio", show_banner=False)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/doctr-mcp/doctr_mcp/server.py
+++ b/src/doctr-mcp/doctr_mcp/server.py
@@ -46,15 +46,20 @@ logger = logging.getLogger(__name__)
 mcp = FastMCP(
     name="doctr_mcp",
     instructions=(
-        "OCR MCP server built on mindee/doctr. "
+        # Critical directive first: this string is truncated to a per-server
+        # character budget (Pincer's mcp_instructions_max_chars, 400 by
+        # default) when surfaced into the caller's system prompt, so the
+        # instruction that actually changes model behavior must survive
+        # truncation — the descriptive tool catalog after it is a bonus.
+        "OCR MCP server (mindee/doctr). ALWAYS hand PDFs/images to these tools — "
+        "do not transcribe or describe their text content yourself via your own "
+        "vision, and do not use file_read, shell_exec, or python_exec on them. "
         "Use ocr_document_text for a quick plain-text read of an image or PDF. "
         "Use ocr_document for the full block/line/word tree with geometry, "
         "orientation, and language detection. "
         "Use detect_text / recognize_text for the individual detection "
         "or recognition stages, extract_key_info for key-information extraction, "
         "and list_architectures to discover valid det_arch/reco_arch values. "
-        "Do not attempt to read PDF or image files yourself with file_read, shell_exec, "
-        "or python_exec — hand them to this server's OCR tools instead. "
         "(Tool names may appear with an additional server-name prefix depending on "
         "how the connecting MCP client namespaces tools.)"
     ),

--- a/src/doctr-mcp/doctr_mcp/tools_detection.py
+++ b/src/doctr-mcp/doctr_mcp/tools_detection.py
@@ -1,0 +1,63 @@
+"""detect_text — text detection only, no recognition."""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING
+
+from doctr_mcp import io_utils
+from doctr_mcp.predictors import PredictorParams, get_predictor, run_predictor
+from doctr_mcp.schemas import DetectionBox, DetectionInput, DetectionOutput, DetectionResult
+
+if TYPE_CHECKING:
+    from fastmcp import FastMCP
+
+logger = logging.getLogger(__name__)
+
+
+def register_detection_tools(mcp: FastMCP) -> None:
+    @mcp.tool
+    async def detect_text(params: DetectionInput) -> DetectionOutput:
+        """Detect text regions in an image or PDF (no text recognition).
+
+        Returns one result per page, each with a list of boxes/polygons — flat
+        [xmin, ymin, xmax, ymax] for straight pages, flat 8-float 4-point polygons
+        for rotated pages — and a confidence score where the architecture reports one.
+        """
+        logger.info("tool: detect_text")
+        data, decoded_filename = io_utils.decode_input(params.source.image_b64, params.source.file_path)
+        filename = params.source.filename or decoded_filename
+        pages, names = io_utils.documents_from_bytes(data, filename, params.page_range)
+
+        predictor_params = PredictorParams(
+            task="detection",
+            det_arch=params.det_arch,
+            assume_straight_pages=params.assume_straight_pages,
+            preserve_aspect_ratio=params.preserve_aspect_ratio,
+            symmetric_pad=params.symmetric_pad,
+            det_bs=params.det_bs,
+            bin_thresh=params.bin_thresh,
+            box_thresh=params.box_thresh,
+        )
+        predictor = await get_predictor(predictor_params)
+        raw_results = await run_predictor(predictor, pages)
+
+        from doctr.file_utils import CLASS_NAME
+
+        results = []
+        for doc, name in zip(raw_results, names, strict=True):
+            boxes = []
+            for geom in doc[CLASS_NAME]:
+                if geom.shape == (5,):
+                    geom_list = geom.tolist()
+                    boxes.append(
+                        DetectionBox(
+                            geometry=tuple(geom_list[:-1]),
+                            confidence=io_utils.round_confidence(geom_list[-1]),
+                        )
+                    )
+                else:
+                    boxes.append(DetectionBox(geometry=io_utils.resolve_geometry(geom[:4].tolist()), confidence=None))
+            results.append(DetectionResult(name=name, boxes=boxes))
+
+        return DetectionOutput(results=results)

--- a/src/doctr-mcp/doctr_mcp/tools_kie.py
+++ b/src/doctr-mcp/doctr_mcp/tools_kie.py
@@ -1,0 +1,84 @@
+"""extract_key_info — key-information extraction (KIE)."""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING
+
+from doctr_mcp import io_utils
+from doctr_mcp.predictors import PredictorParams, get_predictor, run_predictor
+from doctr_mcp.schemas import (
+    CropOrientation,
+    KieClassPredictions,
+    KieInput,
+    KieItem,
+    KieOutput,
+    KiePage,
+    OcrLanguage,
+    OcrPageValue,
+)
+
+if TYPE_CHECKING:
+    from fastmcp import FastMCP
+
+logger = logging.getLogger(__name__)
+
+
+def register_kie_tools(mcp: FastMCP) -> None:
+    @mcp.tool
+    async def extract_key_info(params: KieInput) -> KieOutput:
+        """Run key-information extraction (KIE) on an image or PDF.
+
+        Returns, per page, predictions grouped by detected class name — each
+        prediction has value, geometry, objectness/confidence scores, and crop
+        orientation. Unlike ocr_document, output is organized by class, not
+        as a block/line tree.
+        """
+        logger.info("tool: extract_key_info")
+        data, decoded_filename = io_utils.decode_input(params.source.image_b64, params.source.file_path)
+        filename = params.source.filename or decoded_filename
+        pages, names = io_utils.documents_from_bytes(data, filename, params.page_range)
+
+        predictor_params = PredictorParams(
+            task="kie",
+            det_arch=params.det_arch,
+            reco_arch=params.reco_arch,
+            assume_straight_pages=params.assume_straight_pages,
+            preserve_aspect_ratio=params.preserve_aspect_ratio,
+            symmetric_pad=params.symmetric_pad,
+            detect_language=params.detect_language,
+            det_bs=params.det_bs,
+            reco_bs=params.reco_bs,
+            bin_thresh=params.bin_thresh,
+            box_thresh=params.box_thresh,
+        )
+        predictor = await get_predictor(predictor_params)
+        document = await run_predictor(predictor, pages)
+
+        kie_pages = [
+            KiePage(
+                name=name,
+                orientation=OcrPageValue(**page.orientation),
+                language=OcrLanguage(**page.language),
+                dimensions=tuple(page.dimensions),
+                predictions=[
+                    KieClassPredictions(
+                        class_name=class_name,
+                        items=[
+                            KieItem(
+                                value=prediction.value,
+                                geometry=io_utils.resolve_geometry(prediction.geometry),
+                                objectness_score=io_utils.round_confidence(prediction.objectness_score),
+                                confidence=io_utils.round_confidence(prediction.confidence),
+                                crop_orientation=CropOrientation(**prediction.crop_orientation),
+                            )
+                            for prediction in predictions
+                        ],
+                    )
+                    for class_name, predictions in page.predictions.items()
+                ],
+            )
+            for page, name in zip(document.pages, names, strict=True)
+        ]
+
+        return KieOutput(pages=kie_pages)

--- a/src/doctr-mcp/doctr_mcp/tools_meta.py
+++ b/src/doctr-mcp/doctr_mcp/tools_meta.py
@@ -1,0 +1,37 @@
+"""list_architectures — discovery tool for valid det_arch/reco_arch values.
+Documentation only, not enforced: tool inputs accept any string here, per product
+decision, so a caller isn't limited to a hard-coded Literal[...] enum."""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING
+
+from doctr_mcp.config import KNOWN_DET_ARCHS, KNOWN_RECO_ARCHS, get_settings
+from doctr_mcp.schemas import ListArchitecturesInput, ListArchitecturesOutput
+
+if TYPE_CHECKING:
+    from fastmcp import FastMCP
+
+logger = logging.getLogger(__name__)
+
+
+def register_meta_tools(mcp: FastMCP) -> None:
+    @mcp.tool
+    async def list_architectures(params: ListArchitecturesInput) -> ListArchitecturesOutput:
+        """List doctr's supported detection/recognition architecture names.
+
+        det_arch/reco_arch parameters on other tools accept any of these strings
+        (or, in principle, any name doctr itself supports — this list is not
+        enforced). Use this tool to discover valid values instead of guessing.
+        """
+        logger.info("tool: list_architectures")
+        settings = get_settings()
+        return ListArchitecturesOutput(
+            detection=list(KNOWN_DET_ARCHS),
+            recognition=list(KNOWN_RECO_ARCHS),
+            defaults={
+                "det_arch": settings.default_det_arch,
+                "reco_arch": settings.default_reco_arch,
+            },
+        )

--- a/src/doctr-mcp/doctr_mcp/tools_ocr.py
+++ b/src/doctr-mcp/doctr_mcp/tools_ocr.py
@@ -1,0 +1,123 @@
+"""ocr_document (full block/line/word tree) and ocr_document_text
+(plain-text convenience, sharing the same predictor/params so identical calls to
+either tool hit the same cached predictor)."""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING, Any
+
+from doctr_mcp import io_utils
+from doctr_mcp.predictors import PredictorParams, get_predictor, run_predictor
+from doctr_mcp.schemas import (
+    CropOrientation,
+    OcrBlock,
+    OcrDocumentInput,
+    OcrDocumentOutput,
+    OcrDocumentTextInput,
+    OcrDocumentTextOutput,
+    OcrLanguage,
+    OcrLine,
+    OcrPage,
+    OcrPageValue,
+    OcrWord,
+)
+
+if TYPE_CHECKING:
+    from fastmcp import FastMCP
+
+logger = logging.getLogger(__name__)
+
+
+def _predictor_params_from_ocr_input(params: OcrDocumentInput) -> PredictorParams:
+    return PredictorParams(
+        task="ocr",
+        det_arch=params.det_arch,
+        reco_arch=params.reco_arch,
+        assume_straight_pages=params.assume_straight_pages,
+        preserve_aspect_ratio=params.preserve_aspect_ratio,
+        symmetric_pad=params.symmetric_pad,
+        detect_orientation=params.detect_orientation,
+        straighten_pages=params.straighten_pages,
+        detect_language=params.detect_language,
+        det_bs=params.det_bs,
+        reco_bs=params.reco_bs,
+        bin_thresh=params.bin_thresh,
+        box_thresh=params.box_thresh,
+        resolve_lines=params.resolve_lines,
+        resolve_blocks=params.resolve_blocks,
+        paragraph_break=params.paragraph_break,
+    )
+
+
+async def _run_ocr(params: OcrDocumentInput) -> tuple[Any, list[str]]:
+    data, decoded_filename = io_utils.decode_input(params.source.image_b64, params.source.file_path)
+    filename = params.source.filename or decoded_filename
+    pages, names = io_utils.documents_from_bytes(data, filename, params.page_range)
+
+    predictor_params = _predictor_params_from_ocr_input(params)
+    predictor = await get_predictor(predictor_params)
+    document = await run_predictor(predictor, pages)
+    return document, names
+
+
+def _build_ocr_page(page: Any, name: str) -> OcrPage:
+    return OcrPage(
+        name=name,
+        orientation=OcrPageValue(**page.orientation),
+        language=OcrLanguage(**page.language),
+        dimensions=tuple(page.dimensions),
+        blocks=[
+            OcrBlock(
+                geometry=io_utils.resolve_geometry(block.geometry),
+                objectness_score=io_utils.round_confidence(block.objectness_score),
+                lines=[
+                    OcrLine(
+                        geometry=io_utils.resolve_geometry(line.geometry),
+                        objectness_score=io_utils.round_confidence(line.objectness_score),
+                        words=[
+                            OcrWord(
+                                value=word.value,
+                                geometry=io_utils.resolve_geometry(word.geometry),
+                                objectness_score=io_utils.round_confidence(word.objectness_score),
+                                confidence=io_utils.round_confidence(word.confidence),
+                                crop_orientation=CropOrientation(**word.crop_orientation),
+                            )
+                            for word in line.words
+                        ],
+                    )
+                    for line in block.lines
+                ],
+            )
+            for block in page.blocks
+        ],
+    )
+
+
+def register_ocr_tools(mcp: FastMCP) -> None:
+    @mcp.tool
+    async def ocr_document(params: OcrDocumentInput) -> OcrDocumentOutput:
+        """Run full end-to-end OCR on an image or PDF.
+
+        Returns the complete page -> block -> line -> word tree with geometry,
+        confidence/objectness scores, orientation, and language. For a cheaper
+        plain-text read, use ocr_document_text instead.
+        """
+        logger.info("tool: ocr_document")
+        document, names = await _run_ocr(params)
+        pages = [_build_ocr_page(page, name) for page, name in zip(document.pages, names, strict=True)]
+        return OcrDocumentOutput(pages=pages)
+
+    @mcp.tool
+    async def ocr_document_text(params: OcrDocumentTextInput) -> OcrDocumentTextOutput:
+        """Run OCR and return plain text only — no geometry or confidence scores.
+
+        Uses the same predictor and parameters as ocr_document (identical
+        calls to either tool share one cached predictor); this is the cheap "just
+        read this document" path most callers want. Use ocr_document when
+        you need bounding boxes or confidence scores.
+        """
+        logger.info("tool: ocr_document_text")
+        document, _names = await _run_ocr(params)
+        page_texts = [page.render() for page in document.pages]
+        return OcrDocumentTextOutput(pages=page_texts, text=document.render())

--- a/src/doctr-mcp/doctr_mcp/tools_recognition.py
+++ b/src/doctr-mcp/doctr_mcp/tools_recognition.py
@@ -1,0 +1,43 @@
+"""recognize_text — text recognition only, on pre-cropped word/line images."""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING
+
+from doctr_mcp import io_utils
+from doctr_mcp.predictors import PredictorParams, get_predictor, run_predictor
+from doctr_mcp.schemas import RecognitionInput, RecognitionItem, RecognitionOutput
+
+if TYPE_CHECKING:
+    from fastmcp import FastMCP
+
+logger = logging.getLogger(__name__)
+
+
+def register_recognition_tools(mcp: FastMCP) -> None:
+    @mcp.tool
+    async def recognize_text(params: RecognitionInput) -> RecognitionOutput:
+        """Recognize text in a batch of pre-cropped word/line images.
+
+        Each image should already be tightly cropped to a single line or word — use
+        detect_text or ocr_document first to locate text regions in a
+        full page. Returns one {text, confidence} result per input image, in order.
+        """
+        logger.info("tool: recognize_text (n=%d)", len(params.images))
+        crops = []
+        for source in params.images:
+            data, decoded_filename = io_utils.decode_input(source.image_b64, source.file_path)
+            filename = source.filename or decoded_filename
+            pages, _ = io_utils.documents_from_bytes(data, filename, page_range=None)
+            crops.extend(pages)
+
+        predictor_params = PredictorParams(task="recognition", reco_arch=params.reco_arch, reco_bs=params.reco_bs)
+        predictor = await get_predictor(predictor_params)
+        raw_results = await run_predictor(predictor, crops)
+
+        results = [
+            RecognitionItem(text=text, confidence=io_utils.round_confidence(confidence))
+            for text, confidence in raw_results
+        ]
+        return RecognitionOutput(results=results)

--- a/src/doctr-mcp/pyproject.toml
+++ b/src/doctr-mcp/pyproject.toml
@@ -14,6 +14,9 @@ dependencies = [
     # broken (empty `fastmcp/__init__.py`, `FastMCP` unimportable). 3.2.4 is the
     # version this whole server is built and tested against.
     "fastmcp==3.2.4",
+    # Imported directly for JSONResponse in server.py — already a transitive dep of
+    # fastmcp/starlette, but listed explicitly since it's used directly here.
+    "fastapi>=0.115.0",
     "uvicorn[standard]>=0.34.0",
     "starlette>=0.41.0",
     "pydantic>=2.4.1,<3.0",

--- a/src/doctr-mcp/pyproject.toml
+++ b/src/doctr-mcp/pyproject.toml
@@ -1,0 +1,77 @@
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "doctr-mcp"
+version = "0.1.0"
+requires-python = ">=3.12"
+dependencies = [
+    # Pinned to a released version, not `main` (unlike doctr's own `api/pyproject.toml`,
+    # which intentionally tracks its dev branch) — reproducibility matters more here.
+    "python-doctr==1.0.1",
+    # See src/ms365-mcp/pyproject.toml's comment: fastmcp 3.4.2's PyPI packaging is
+    # broken (empty `fastmcp/__init__.py`, `FastMCP` unimportable). 3.2.4 is the
+    # version this whole server is built and tested against.
+    "fastmcp==3.2.4",
+    "uvicorn[standard]>=0.34.0",
+    "starlette>=0.41.0",
+    "pydantic>=2.4.1,<3.0",
+    "pydantic-settings>=2.0.0",
+    "pillow>=10.1.0",
+    # torch/torchvision are already transitive deps of python-doctr, but uv's
+    # `[tool.uv.sources]` index redirection (below) only applies to packages listed
+    # as *direct* dependencies here — hence the explicit listing, version-aligned
+    # with python-doctr 1.0.1's own constraints.
+    "torch>=2.0.0,<3.0.0",
+    "torchvision>=0.15.0",
+]
+
+[project.optional-dependencies]
+telemetry = [
+    "pincer-telemetry @ git+https://github.com/pincerhq/pincer-telemetry.git@main"
+]
+dev = [
+    "pytest>=8.3.0",
+    "pytest-asyncio>=0.24.0",
+    "pytest-cov>=6.0.0",
+    "httpx>=0.27.0",
+]
+
+[project.scripts]
+doctr-mcp-run = "doctr_mcp.server:main"
+
+[tool.hatch.metadata]
+allow-direct-references = true
+
+[tool.hatch.build.targets.wheel]
+packages = ["doctr_mcp"]
+
+[tool.pytest.ini_options]
+asyncio_mode = "auto"
+testpaths = ["tests"]
+pythonpath = ["."]
+
+# Force CPU-only torch/torchvision wheels — python-doctr depends on torch/torchvision
+# directly with no CPU-only extra, and letting uv resolve the default PyPI wheels here
+# would pull full CUDA builds (multi-GB) into an image that never uses a GPU by default.
+# The `platform_system != 'Darwin'` marker matters because download.pytorch.org's
+# "cpu" index does not publish macOS wheels at all (macOS-arm64 only ever gets a
+# combined CPU/MPS build from PyPI) — this is uv's documented recipe for CPU-only
+# torch: https://docs.astral.sh/uv/guides/integration/pytorch/#configuring-cpu-only-builds
+#
+# The `[[tool.uv.index]]` block below is duplicated in the workspace *root*
+# pyproject.toml. uv only reads index definitions from whichever pyproject.toml is
+# acting as the resolution root: the outer workspace root when this package is
+# resolved as a workspace member (the normal dev flow), or this file itself when
+# the Dockerfile copies only `src/doctr-mcp/` as a standalone build context (this
+# server's own build, since its image is far heavier than the other bundled
+# servers'). Both copies must stay in sync if the index URL ever changes.
+[tool.uv.sources]
+torch = [{ index = "pytorch-cpu", marker = "platform_system != 'Darwin'" }]
+torchvision = [{ index = "pytorch-cpu", marker = "platform_system != 'Darwin'" }]
+
+[[tool.uv.index]]
+name = "pytorch-cpu"
+url = "https://download.pytorch.org/whl/cpu"
+explicit = true

--- a/src/doctr-mcp/tests/conftest.py
+++ b/src/doctr-mcp/tests/conftest.py
@@ -1,0 +1,187 @@
+"""Shared fixtures for doctr-mcp tests.
+
+No real torch/doctr model is ever built or downloaded in these tests: every test
+that would trigger predictor construction monkeypatches
+`doctr_mcp.predictors.predictor_builder` with a fake, duck-typed to match the shape
+of doctr's own Page/Document/Prediction objects.
+"""
+
+from __future__ import annotations
+
+import base64
+from collections.abc import Iterator
+from io import BytesIO
+from typing import Any
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _reset_module_state() -> Iterator[None]:
+    """Fresh predictor cache/locks and settings for every test."""
+    from doctr_mcp import predictors
+    from doctr_mcp.config import get_settings
+
+    predictors.reset_state()
+    get_settings.cache_clear()
+    yield
+    predictors.reset_state()
+    get_settings.cache_clear()
+
+
+@pytest.fixture
+def tiny_png_b64() -> str:
+    from PIL import Image
+
+    buf = BytesIO()
+    Image.new("RGB", (16, 16), color="white").save(buf, format="PNG")
+    return base64.b64encode(buf.getvalue()).decode("ascii")
+
+
+# ---------------------------------------------------------------------------
+# Fake doctr-shaped objects (duck-typed, no doctr/torch import)
+# ---------------------------------------------------------------------------
+
+
+class FakeWord:
+    def __init__(
+        self,
+        value: str = "HELLO",
+        confidence: float = 0.951,
+        geometry: Any = ((0.1, 0.1), (0.2, 0.2)),
+        objectness_score: float = 0.901,
+        crop_orientation: dict[str, Any] | None = None,
+    ) -> None:
+        self.value = value
+        self.confidence = confidence
+        self.geometry = geometry
+        self.objectness_score = objectness_score
+        self.crop_orientation = crop_orientation or {"value": 0, "confidence": None}
+
+    def render(self) -> str:
+        return self.value
+
+
+class FakeLine:
+    def __init__(self, words: list[FakeWord]) -> None:
+        self.words = words
+        self.geometry = ((0.1, 0.1), (0.9, 0.2))
+        self.objectness_score = 0.9
+
+    def render(self) -> str:
+        return " ".join(w.render() for w in self.words)
+
+
+class FakeBlock:
+    def __init__(self, lines: list[FakeLine]) -> None:
+        self.lines = lines
+        self.geometry = ((0.1, 0.1), (0.9, 0.9))
+        self.objectness_score = 0.9
+
+    def render(self) -> str:
+        return "\n".join(line.render() for line in self.lines)
+
+
+class FakePage:
+    def __init__(
+        self,
+        blocks: list[FakeBlock] | None = None,
+        orientation: dict[str, Any] | None = None,
+        language: dict[str, Any] | None = None,
+        dimensions: tuple[int, int] = (100, 200),
+    ) -> None:
+        self.blocks = blocks if blocks is not None else [FakeBlock([FakeLine([FakeWord()])])]
+        self.orientation = orientation or {"value": 0, "confidence": None}
+        self.language = language or {"value": None, "confidence": None}
+        self.dimensions = dimensions
+
+    def render(self) -> str:
+        return "\n\n".join(b.render() for b in self.blocks)
+
+
+class FakeDocument:
+    def __init__(self, pages: list[FakePage]) -> None:
+        self.pages = pages
+
+    def render(self) -> str:
+        return "\n\n\n\n".join(p.render() for p in self.pages)
+
+
+class FakePrediction:
+    def __init__(
+        self,
+        value: str = "42.00",
+        confidence: float = 0.9,
+        geometry: Any = ((0.1, 0.1), (0.2, 0.2)),
+        objectness_score: float = 0.9,
+        crop_orientation: dict[str, Any] | None = None,
+    ) -> None:
+        self.value = value
+        self.confidence = confidence
+        self.geometry = geometry
+        self.objectness_score = objectness_score
+        self.crop_orientation = crop_orientation or {"value": 0, "confidence": None}
+
+
+class FakeKiePage:
+    def __init__(
+        self,
+        predictions: dict[str, list[FakePrediction]] | None = None,
+        orientation: dict[str, Any] | None = None,
+        language: dict[str, Any] | None = None,
+        dimensions: tuple[int, int] = (100, 200),
+    ) -> None:
+        self.predictions = predictions if predictions is not None else {"total_price": [FakePrediction()]}
+        self.orientation = orientation or {"value": 0, "confidence": None}
+        self.language = language or {"value": None, "confidence": None}
+        self.dimensions = dimensions
+
+
+class FakeKieDocument:
+    def __init__(self, pages: list[FakeKiePage]) -> None:
+        self.pages = pages
+
+
+class FakeDetPredictor:
+    def __call__(self, pages: list[Any]) -> list[dict[str, Any]]:
+        import numpy as np
+
+        return [{"words": np.array([[0.1, 0.1, 0.2, 0.2, 0.93]])} for _ in pages]
+
+
+class FakeRecoPredictor:
+    def __call__(self, crops: list[Any]) -> list[tuple[str, float]]:
+        return [("HELLO", 0.951) for _ in crops]
+
+
+class FakeOcrPredictor:
+    def __call__(self, pages: list[Any]) -> FakeDocument:
+        return FakeDocument(pages=[FakePage() for _ in pages])
+
+
+class FakeKiePredictor:
+    def __call__(self, pages: list[Any]) -> FakeKieDocument:
+        return FakeKieDocument(pages=[FakeKiePage() for _ in pages])
+
+
+@pytest.fixture
+def fake_predictor_builder(monkeypatch: pytest.MonkeyPatch) -> list[Any]:
+    """Patch doctr_mcp.predictors.predictor_builder so no real torch/doctr model is
+    ever built. Returns the list of PredictorParams each call was made with, so
+    tests can assert on cache-key behavior."""
+    from doctr_mcp import predictors
+
+    build_calls: list[Any] = []
+
+    def _fake_builder(params: Any) -> Any:
+        build_calls.append(params)
+        if params.task == "detection":
+            return FakeDetPredictor()
+        if params.task == "recognition":
+            return FakeRecoPredictor()
+        if params.task == "kie":
+            return FakeKiePredictor()
+        return FakeOcrPredictor()
+
+    monkeypatch.setattr(predictors, "predictor_builder", _fake_builder)
+    return build_calls

--- a/src/doctr-mcp/tests/test_config.py
+++ b/src/doctr-mcp/tests/test_config.py
@@ -1,0 +1,24 @@
+"""Tests for DoctrSettings — request-logging fields in particular."""
+
+from __future__ import annotations
+
+import pytest
+
+
+def test_log_tool_requests_defaults() -> None:
+    from doctr_mcp.config import DoctrSettings
+
+    settings = DoctrSettings()
+    assert settings.log_tool_requests is False
+    assert settings.log_max_payload_length == 2000
+
+
+def test_log_tool_requests_env_override(monkeypatch: pytest.MonkeyPatch) -> None:
+    from doctr_mcp.config import DoctrSettings
+
+    monkeypatch.setenv("DOCTR_LOG_TOOL_REQUESTS", "true")
+    monkeypatch.setenv("DOCTR_LOG_MAX_PAYLOAD_LENGTH", "500")
+
+    settings = DoctrSettings()
+    assert settings.log_tool_requests is True
+    assert settings.log_max_payload_length == 500

--- a/src/doctr-mcp/tests/test_io_utils.py
+++ b/src/doctr-mcp/tests/test_io_utils.py
@@ -1,0 +1,87 @@
+"""Tests for base64/file_path decoding, mime sniffing, and geometry flattening."""
+
+from __future__ import annotations
+
+import base64
+from pathlib import Path
+
+import pytest
+from doctr_mcp import io_utils
+
+
+def test_decode_input_requires_exactly_one_source() -> None:
+    with pytest.raises(io_utils.InputError, match="exactly one"):
+        io_utils.decode_input("Zm9v", "/tmp/x.png")
+    with pytest.raises(io_utils.InputError, match="Provide one"):
+        io_utils.decode_input(None, None)
+
+
+def test_decode_input_invalid_base64() -> None:
+    with pytest.raises(io_utils.InputError, match="not valid base64"):
+        io_utils.decode_input("not-valid-base64!!!", None)
+
+
+def test_decode_input_from_base64(tiny_png_b64: str) -> None:
+    data, filename = io_utils.decode_input(tiny_png_b64, None)
+    assert data[:8] == b"\x89PNG\r\n\x1a\n"
+    assert filename is None
+
+
+def test_decode_input_from_file_path_requires_absolute(tmp_path: Path) -> None:
+    rel = "relative/path.png"
+    with pytest.raises(io_utils.InputError, match="absolute"):
+        io_utils.decode_input(None, rel)
+
+
+def test_decode_input_from_file_path_missing(tmp_path: Path) -> None:
+    missing = tmp_path / "does_not_exist.png"
+    with pytest.raises(io_utils.InputError, match="does not exist"):
+        io_utils.decode_input(None, str(missing))
+
+
+def test_decode_input_from_file_path(tmp_path: Path, tiny_png_b64: str) -> None:
+    raw = base64.b64decode(tiny_png_b64)
+    path = tmp_path / "scan.png"
+    path.write_bytes(raw)
+
+    data, filename = io_utils.decode_input(None, str(path))
+    assert data == raw
+    assert filename == "scan.png"
+
+
+def test_decode_input_size_limit(monkeypatch: pytest.MonkeyPatch) -> None:
+    from doctr_mcp.config import get_settings
+
+    monkeypatch.setenv("DOCTR_MAX_INPUT_MB", "0")
+    get_settings.cache_clear()
+    try:
+        with pytest.raises(io_utils.InputError, match="exceeding"):
+            io_utils.decode_input(base64.b64encode(b"x" * 1024).decode(), None)
+    finally:
+        get_settings.cache_clear()
+
+
+def test_documents_from_bytes_image(tiny_png_b64: str) -> None:
+    raw = base64.b64decode(tiny_png_b64)
+    pages, names = io_utils.documents_from_bytes(raw, "scan.png")
+    assert len(pages) == 1
+    assert names == ["scan.png"]
+
+
+def test_documents_from_bytes_unsupported_content() -> None:
+    with pytest.raises(io_utils.InputError, match="Unsupported"):
+        io_utils.documents_from_bytes(b"not a real image or pdf", "mystery.bin")
+
+
+def test_resolve_geometry_box() -> None:
+    box = ((0.1, 0.2), (0.3, 0.4))
+    assert io_utils.resolve_geometry(box) == (0.1, 0.2, 0.3, 0.4)
+
+
+def test_resolve_geometry_polygon() -> None:
+    polygon = ((0.0, 0.0), (0.1, 0.0), (0.1, 0.1), (0.0, 0.1))
+    assert io_utils.resolve_geometry(polygon) == (0.0, 0.0, 0.1, 0.0, 0.1, 0.1, 0.0, 0.1)
+
+
+def test_round_confidence() -> None:
+    assert io_utils.round_confidence(0.94999) == 0.95

--- a/src/doctr-mcp/tests/test_predictors.py
+++ b/src/doctr-mcp/tests/test_predictors.py
@@ -1,0 +1,112 @@
+"""Tests for the predictor cache/lock lifecycle. No real torch/doctr model is built."""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+
+import pytest
+from doctr_mcp.predictors import PredictorParams, get_predictor, run_predictor
+
+
+@pytest.mark.asyncio
+async def test_same_params_share_cached_predictor(fake_predictor_builder: list[Any]) -> None:
+    params = PredictorParams(task="ocr", det_arch="db_resnet50")
+    p1 = await get_predictor(params)
+    p2 = await get_predictor(params)
+    assert p1 is p2
+    assert len(fake_predictor_builder) == 1
+
+
+@pytest.mark.asyncio
+async def test_different_thresholds_build_different_predictors(fake_predictor_builder: list[Any]) -> None:
+    """docTR mutates bin_thresh/box_thresh as instance attributes post-construction —
+    the cache key must include them or two different-threshold calls would race on
+    one shared predictor."""
+    p1 = await get_predictor(PredictorParams(task="ocr", bin_thresh=0.1))
+    p2 = await get_predictor(PredictorParams(task="ocr", bin_thresh=0.5))
+    assert p1 is not p2
+    assert len(fake_predictor_builder) == 2
+
+
+@pytest.mark.asyncio
+async def test_different_architectures_build_different_predictors(fake_predictor_builder: list[Any]) -> None:
+    p1 = await get_predictor(PredictorParams(task="detection", det_arch="db_resnet50"))
+    p2 = await get_predictor(PredictorParams(task="detection", det_arch="fast_base"))
+    assert p1 is not p2
+
+
+@pytest.mark.asyncio
+async def test_lru_eviction_bounds_cache_size(
+    monkeypatch: pytest.MonkeyPatch, fake_predictor_builder: list[Any]
+) -> None:
+    from doctr_mcp import predictors
+    from doctr_mcp.config import get_settings
+
+    monkeypatch.setenv("DOCTR_MAX_CACHED_PREDICTORS", "2")
+    get_settings.cache_clear()
+
+    p1 = await get_predictor(PredictorParams(task="ocr", det_arch="a1"))
+    await get_predictor(PredictorParams(task="ocr", det_arch="a2"))
+    await get_predictor(PredictorParams(task="ocr", det_arch="a3"))  # evicts a1
+
+    assert len(predictors._get_cache()) == 2  # noqa: SLF001
+
+    # a1 was evicted, so requesting it again must rebuild (4th build call).
+    p1_again = await get_predictor(PredictorParams(task="ocr", det_arch="a1"))
+    assert p1_again is not p1
+    assert len(fake_predictor_builder) == 4
+
+
+@pytest.mark.asyncio
+async def test_concurrent_calls_for_same_key_build_exactly_once(monkeypatch: pytest.MonkeyPatch) -> None:
+    from doctr_mcp import predictors
+
+    build_count = 0
+
+    def _sync_wrapper(params: object) -> str:
+        # get_predictor calls predictor_builder via asyncio.to_thread, so it must be
+        # a plain sync callable; simulate slowness with a thread-safe sleep instead.
+        nonlocal build_count
+        build_count += 1
+        import time
+
+        time.sleep(0.05)
+        return "predictor"
+
+    monkeypatch.setattr(predictors, "predictor_builder", _sync_wrapper)
+
+    params = PredictorParams(task="ocr")
+    results = await asyncio.gather(*(get_predictor(params) for _ in range(5)))
+
+    assert build_count == 1
+    assert all(r == "predictor" for r in results)
+
+
+@pytest.mark.asyncio
+async def test_run_predictor_respects_max_workers(monkeypatch: pytest.MonkeyPatch) -> None:
+    from doctr_mcp.config import get_settings
+
+    monkeypatch.setenv("DOCTR_MAX_WORKERS", "1")
+    get_settings.cache_clear()
+    # Force a fresh semaphore for the new setting.
+    import doctr_mcp.predictors as predictors_module
+
+    predictors_module._inference_semaphore = None  # noqa: SLF001
+
+    concurrent = 0
+    max_concurrent = 0
+
+    def _predictor(pages: list[int]) -> list[int]:
+        nonlocal concurrent, max_concurrent
+        concurrent += 1
+        max_concurrent = max(max_concurrent, concurrent)
+        import time
+
+        time.sleep(0.05)
+        concurrent -= 1
+        return pages
+
+    await asyncio.gather(*(run_predictor(_predictor, [i]) for i in range(4)))
+
+    assert max_concurrent == 1

--- a/src/doctr-mcp/tests/test_schemas.py
+++ b/src/doctr-mcp/tests/test_schemas.py
@@ -1,0 +1,39 @@
+"""Tests for pydantic input model validation edge cases."""
+
+from __future__ import annotations
+
+import pytest
+from doctr_mcp.schemas import DetectionInput, ImageSource, OcrDocumentInput
+from pydantic import ValidationError
+
+
+def test_image_source_requires_exactly_one() -> None:
+    with pytest.raises(ValidationError):
+        ImageSource()
+    with pytest.raises(ValidationError):
+        ImageSource(image_b64="Zm9v", file_path="/tmp/x.png")
+
+
+def test_image_source_accepts_b64_only() -> None:
+    source = ImageSource(image_b64="Zm9v")
+    assert source.file_path is None
+
+
+def test_image_source_accepts_file_path_only() -> None:
+    source = ImageSource(file_path="/tmp/x.png")
+    assert source.image_b64 is None
+
+
+def test_detection_input_rejects_unknown_fields() -> None:
+    with pytest.raises(ValidationError):
+        DetectionInput(source=ImageSource(image_b64="Zm9v"), unexpected_field=123)  # type: ignore[call-arg]
+
+
+def test_detection_input_defaults_from_settings() -> None:
+    params = DetectionInput(source=ImageSource(image_b64="Zm9v"))
+    assert params.det_arch  # populated via default_factory, non-empty
+
+
+def test_ocr_document_input_page_range_is_a_tuple() -> None:
+    params = OcrDocumentInput(source=ImageSource(image_b64="Zm9v"), page_range=(0, 3))
+    assert params.page_range == (0, 3)

--- a/src/doctr-mcp/tests/test_server.py
+++ b/src/doctr-mcp/tests/test_server.py
@@ -29,6 +29,18 @@ def test_root_endpoint() -> None:
     assert resp.json()["status"] == "healthy"
 
 
+def test_instructions_warn_against_self_reading_pdfs() -> None:
+    """The server's instructions must steer callers away from reading PDF/image
+    files with generic tools instead of this server's OCR tools — this text is
+    surfaced into Pincer's own system prompt via MCPClientSession.instructions."""
+    from doctr_mcp.server import mcp
+
+    assert mcp.instructions is not None
+    assert "file_read" in mcp.instructions
+    assert "shell_exec" in mcp.instructions
+    assert "python_exec" in mcp.instructions
+
+
 def test_parse_args_defaults(monkeypatch: pytest.MonkeyPatch) -> None:
     from doctr_mcp import server
 
@@ -68,3 +80,84 @@ async def test_list_architectures_tool() -> None:
     assert "db_resnet50" in data["detection"]
     assert "crnn_vgg16_bn" in data["recognition"]
     assert data["defaults"]["det_arch"] == "db_resnet50"
+
+
+def test_log_tool_requests_disabled_by_default() -> None:
+    from doctr_mcp.server import mcp
+    from fastmcp.server.middleware.logging import LoggingMiddleware
+
+    assert not any(isinstance(m, LoggingMiddleware) for m in mcp.middleware)
+
+
+def test_log_tool_requests_attaches_logging_middleware(monkeypatch: pytest.MonkeyPatch) -> None:
+    import importlib
+
+    from doctr_mcp import server
+    from doctr_mcp.config import get_settings
+    from fastmcp.server.middleware.logging import LoggingMiddleware
+
+    monkeypatch.setenv("DOCTR_LOG_TOOL_REQUESTS", "true")
+    get_settings.cache_clear()
+    try:
+        importlib.reload(server)
+        assert any(isinstance(m, LoggingMiddleware) for m in server.mcp.middleware)
+    finally:
+        monkeypatch.delenv("DOCTR_LOG_TOOL_REQUESTS", raising=False)
+        get_settings.cache_clear()
+        importlib.reload(server)
+
+
+@pytest.mark.asyncio
+async def test_log_tool_requests_logs_call_payload(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    import importlib
+    import logging as logging_module
+
+    from doctr_mcp import server
+    from doctr_mcp.config import get_settings
+
+    monkeypatch.setenv("DOCTR_LOG_TOOL_REQUESTS", "true")
+    get_settings.cache_clear()
+    try:
+        importlib.reload(server)
+        with caplog.at_level(logging_module.INFO, logger="doctr_mcp.requests"):
+            await server.mcp.call_tool("list_architectures", {"params": {}})
+        records = [r for r in caplog.records if r.name == "doctr_mcp.requests"]
+        assert records
+        assert any("list_architectures" in r.message for r in records)
+    finally:
+        monkeypatch.delenv("DOCTR_LOG_TOOL_REQUESTS", raising=False)
+        get_settings.cache_clear()
+        importlib.reload(server)
+
+
+@pytest.mark.asyncio
+async def test_log_tool_requests_truncates_payload(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    import importlib
+    import logging as logging_module
+
+    from doctr_mcp import server
+    from doctr_mcp.config import get_settings
+
+    monkeypatch.setenv("DOCTR_LOG_TOOL_REQUESTS", "true")
+    monkeypatch.setenv("DOCTR_LOG_MAX_PAYLOAD_LENGTH", "20")
+    get_settings.cache_clear()
+    try:
+        importlib.reload(server)
+        with caplog.at_level(logging_module.INFO, logger="doctr_mcp.requests"):
+            await server.mcp.call_tool("list_architectures", {"params": {}})
+        request_records = [
+            r for r in caplog.records if r.name == "doctr_mcp.requests" and "request_start" in r.message
+        ]
+        assert request_records
+        # The truncated payload (20 chars + "...") must be far shorter than the
+        # untruncated CallToolRequestParams JSON would be.
+        assert all("payload=" in r.message and len(r.message) < 200 for r in request_records)
+    finally:
+        monkeypatch.delenv("DOCTR_LOG_TOOL_REQUESTS", raising=False)
+        monkeypatch.delenv("DOCTR_LOG_MAX_PAYLOAD_LENGTH", raising=False)
+        get_settings.cache_clear()
+        importlib.reload(server)

--- a/src/doctr-mcp/tests/test_server.py
+++ b/src/doctr-mcp/tests/test_server.py
@@ -41,6 +41,32 @@ def test_instructions_warn_against_self_reading_pdfs() -> None:
     assert "python_exec" in mcp.instructions
 
 
+def test_instructions_warn_against_self_vision_transcription() -> None:
+    """A vision-capable model that already 'sees' the image has no reason not
+    to just transcribe it itself unless explicitly told otherwise — generic
+    file-tool warnings alone (file_read/shell_exec/python_exec) don't cover
+    that case."""
+    from doctr_mcp.server import mcp
+
+    assert mcp.instructions is not None
+    assert "vision" in mcp.instructions.lower()
+
+
+def test_critical_instruction_survives_default_truncation() -> None:
+    """Pincer truncates each connected server's instructions to a per-server
+    character budget (mcp_instructions_max_chars, 400 by default) before
+    surfacing them into its own system prompt. The directive that actually
+    changes model behavior must land within that budget, or it never reaches
+    the model at all."""
+    from doctr_mcp.server import mcp
+
+    assert mcp.instructions is not None
+    collapsed = " ".join(mcp.instructions.split())
+    truncated = collapsed[:400]
+    assert "do not transcribe" in truncated.lower()
+    assert "file_read" in truncated
+
+
 def test_parse_args_defaults(monkeypatch: pytest.MonkeyPatch) -> None:
     from doctr_mcp import server
 

--- a/src/doctr-mcp/tests/test_server.py
+++ b/src/doctr-mcp/tests/test_server.py
@@ -1,0 +1,70 @@
+"""Tests for the doctr-mcp server module: health endpoint, CLI parsing, meta tool."""
+
+from __future__ import annotations
+
+import pytest
+
+
+def test_health_endpoint() -> None:
+    from doctr_mcp.server import mcp
+    from starlette.testclient import TestClient
+
+    app = mcp.http_app()
+    with TestClient(app, raise_server_exceptions=False) as client:
+        resp = client.get("/health")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["status"] == "healthy"
+    assert data["service"] == "doctr-mcp"
+
+
+def test_root_endpoint() -> None:
+    from doctr_mcp.server import mcp
+    from starlette.testclient import TestClient
+
+    app = mcp.http_app()
+    with TestClient(app, raise_server_exceptions=False) as client:
+        resp = client.get("/")
+    assert resp.status_code == 200
+    assert resp.json()["status"] == "healthy"
+
+
+def test_parse_args_defaults(monkeypatch: pytest.MonkeyPatch) -> None:
+    from doctr_mcp import server
+
+    monkeypatch.delenv("TRANSPORT", raising=False)
+    monkeypatch.setattr("sys.argv", ["doctr-mcp-run"])
+    args = server._parse_args()  # noqa: SLF001
+    assert args.transport == "http"  # this server defaults to HTTP, unlike the other bundled servers
+    assert args.host == "0.0.0.0"
+    assert args.port == 8000
+
+
+def test_parse_args_stdio_override(monkeypatch: pytest.MonkeyPatch) -> None:
+    from doctr_mcp import server
+
+    monkeypatch.setattr("sys.argv", ["doctr-mcp-run", "--transport", "stdio", "--port", "9001"])
+    args = server._parse_args()  # noqa: SLF001
+    assert args.transport == "stdio"
+    assert args.port == 9001
+
+
+def test_parse_args_reads_transport_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    from doctr_mcp import server
+
+    monkeypatch.setenv("TRANSPORT", "stdio")
+    monkeypatch.setattr("sys.argv", ["doctr-mcp-run"])
+    args = server._parse_args()  # noqa: SLF001
+    assert args.transport == "stdio"
+
+
+@pytest.mark.asyncio
+async def test_list_architectures_tool() -> None:
+    from doctr_mcp.server import mcp
+
+    result = await mcp.call_tool("list_architectures", {"params": {}})
+    data = result.structured_content
+    assert data is not None
+    assert "db_resnet50" in data["detection"]
+    assert "crnn_vgg16_bn" in data["recognition"]
+    assert data["defaults"]["det_arch"] == "db_resnet50"

--- a/src/doctr-mcp/tests/test_server.py
+++ b/src/doctr-mcp/tests/test_server.py
@@ -175,9 +175,7 @@ async def test_log_tool_requests_truncates_payload(
         importlib.reload(server)
         with caplog.at_level(logging_module.INFO, logger="doctr_mcp.requests"):
             await server.mcp.call_tool("list_architectures", {"params": {}})
-        request_records = [
-            r for r in caplog.records if r.name == "doctr_mcp.requests" and "request_start" in r.message
-        ]
+        request_records = [r for r in caplog.records if r.name == "doctr_mcp.requests" and "request_start" in r.message]
         assert request_records
         # The truncated payload (20 chars + "...") must be far shorter than the
         # untruncated CallToolRequestParams JSON would be.

--- a/src/doctr-mcp/tests/test_tools_detection.py
+++ b/src/doctr-mcp/tests/test_tools_detection.py
@@ -1,0 +1,45 @@
+"""Tests for detect_text, calling the real FastMCP server with a mocked predictor."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+
+@pytest.mark.asyncio
+async def test_detect_text_returns_boxes(fake_predictor_builder: list[Any], tiny_png_b64: str) -> None:
+    from doctr_mcp.server import mcp
+
+    result = await mcp.call_tool("detect_text", {"params": {"source": {"image_b64": tiny_png_b64}}})
+    data = result.structured_content
+    assert data is not None
+    assert len(data["results"]) == 1
+    boxes = data["results"][0]["boxes"]
+    assert len(boxes) == 1
+    assert boxes[0]["geometry"] == [0.1, 0.1, 0.2, 0.2]
+    assert boxes[0]["confidence"] == 0.93
+
+
+@pytest.mark.asyncio
+async def test_detect_text_uses_det_arch_in_cache_key(fake_predictor_builder: list[Any], tiny_png_b64: str) -> None:
+    from doctr_mcp.server import mcp
+
+    await mcp.call_tool(
+        "detect_text",
+        {"params": {"source": {"image_b64": tiny_png_b64}, "det_arch": "fast_base"}},
+    )
+    assert fake_predictor_builder[-1].task == "detection"
+    assert fake_predictor_builder[-1].det_arch == "fast_base"
+
+
+@pytest.mark.asyncio
+async def test_detect_text_rejects_both_sources(fake_predictor_builder: list[Any], tiny_png_b64: str) -> None:
+    from doctr_mcp.server import mcp
+    from pydantic import ValidationError
+
+    with pytest.raises(ValidationError, match="exactly one"):
+        await mcp.call_tool(
+            "detect_text",
+            {"params": {"source": {"image_b64": tiny_png_b64, "file_path": "/tmp/x.png"}}},
+        )

--- a/src/doctr-mcp/tests/test_tools_kie.py
+++ b/src/doctr-mcp/tests/test_tools_kie.py
@@ -1,0 +1,27 @@
+"""Tests for extract_key_info."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+
+@pytest.mark.asyncio
+async def test_extract_key_info_groups_by_class(fake_predictor_builder: list[Any], tiny_png_b64: str) -> None:
+    from doctr_mcp.server import mcp
+
+    result = await mcp.call_tool("extract_key_info", {"params": {"source": {"image_b64": tiny_png_b64}}})
+    data = result.structured_content
+    assert data is not None
+    page = data["pages"][0]
+    assert page["predictions"][0]["class_name"] == "total_price"
+    assert page["predictions"][0]["items"][0]["value"] == "42.00"
+
+
+@pytest.mark.asyncio
+async def test_extract_key_info_uses_kie_task(fake_predictor_builder: list[Any], tiny_png_b64: str) -> None:
+    from doctr_mcp.server import mcp
+
+    await mcp.call_tool("extract_key_info", {"params": {"source": {"image_b64": tiny_png_b64}}})
+    assert fake_predictor_builder[-1].task == "kie"

--- a/src/doctr-mcp/tests/test_tools_ocr.py
+++ b/src/doctr-mcp/tests/test_tools_ocr.py
@@ -1,0 +1,59 @@
+"""Tests for ocr_document and ocr_document_text."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+
+@pytest.mark.asyncio
+async def test_ocr_document_returns_full_tree(fake_predictor_builder: list[Any], tiny_png_b64: str) -> None:
+    from doctr_mcp.server import mcp
+
+    result = await mcp.call_tool("ocr_document", {"params": {"source": {"image_b64": tiny_png_b64}}})
+    data = result.structured_content
+    assert data is not None
+    page = data["pages"][0]
+    assert page["blocks"][0]["lines"][0]["words"][0]["value"] == "HELLO"
+    assert page["blocks"][0]["lines"][0]["words"][0]["confidence"] == 0.95
+    assert page["dimensions"] == [100, 200]
+
+
+@pytest.mark.asyncio
+async def test_ocr_document_text_returns_plain_text(fake_predictor_builder: list[Any], tiny_png_b64: str) -> None:
+    from doctr_mcp.server import mcp
+
+    result = await mcp.call_tool("ocr_document_text", {"params": {"source": {"image_b64": tiny_png_b64}}})
+    data = result.structured_content
+    assert data is not None
+    assert data["pages"] == ["HELLO"]
+    assert data["text"] == "HELLO"
+    assert "geometry" not in data
+
+
+@pytest.mark.asyncio
+async def test_ocr_document_and_text_share_cached_predictor_for_same_params(
+    fake_predictor_builder: list[Any], tiny_png_b64: str
+) -> None:
+    """Both tools build a PredictorParams(task='ocr', ...) — identical params should
+    hit the same cache entry regardless of which tool is called first."""
+    from doctr_mcp.server import mcp
+
+    await mcp.call_tool("ocr_document", {"params": {"source": {"image_b64": tiny_png_b64}}})
+    await mcp.call_tool("ocr_document_text", {"params": {"source": {"image_b64": tiny_png_b64}}})
+    assert len(fake_predictor_builder) == 1
+
+
+@pytest.mark.asyncio
+async def test_ocr_document_passes_ocr_only_params(fake_predictor_builder: list[Any], tiny_png_b64: str) -> None:
+    from doctr_mcp.server import mcp
+
+    await mcp.call_tool(
+        "ocr_document",
+        {"params": {"source": {"image_b64": tiny_png_b64}, "resolve_blocks": True, "paragraph_break": 0.05}},
+    )
+    params = fake_predictor_builder[-1]
+    assert params.task == "ocr"
+    assert params.resolve_blocks is True
+    assert params.paragraph_break == 0.05

--- a/src/doctr-mcp/tests/test_tools_recognition.py
+++ b/src/doctr-mcp/tests/test_tools_recognition.py
@@ -1,0 +1,35 @@
+"""Tests for recognize_text."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+
+@pytest.mark.asyncio
+async def test_recognize_text_returns_one_result_per_image(
+    fake_predictor_builder: list[Any], tiny_png_b64: str
+) -> None:
+    from doctr_mcp.server import mcp
+
+    result = await mcp.call_tool(
+        "recognize_text",
+        {"params": {"images": [{"image_b64": tiny_png_b64}, {"image_b64": tiny_png_b64}]}},
+    )
+    data = result.structured_content
+    assert data is not None
+    assert len(data["results"]) == 2
+    assert data["results"][0] == {"text": "HELLO", "confidence": 0.95}
+
+
+@pytest.mark.asyncio
+async def test_recognize_text_uses_reco_arch(fake_predictor_builder: list[Any], tiny_png_b64: str) -> None:
+    from doctr_mcp.server import mcp
+
+    await mcp.call_tool(
+        "recognize_text",
+        {"params": {"images": [{"image_b64": tiny_png_b64}], "reco_arch": "parseq"}},
+    )
+    assert fake_predictor_builder[-1].task == "recognition"
+    assert fake_predictor_builder[-1].reco_arch == "parseq"

--- a/src/pincer/cli.py
+++ b/src/pincer/cli.py
@@ -151,6 +151,32 @@ def run() -> None:
     asyncio.run(_run_agent(settings))
 
 
+def _format_pdf_attachment(pages: list[str], filename: str, abs_path: str, max_chars: int = 30_000) -> str:
+    """Format a PDF attachment's extracted text for the LLM prompt.
+
+    A scanned/image-only PDF has no embedded text layer, so pymupdf's
+    `page.get_text()` returns empty/near-empty strings per page — detect that
+    case (average non-whitespace chars/page below a conservative threshold;
+    real text pages have hundreds, so this only misfires if *every* page in
+    the document is near-blank) and say so explicitly instead of silently
+    reporting a blank code block, so the agent knows to reach for an
+    OCR-capable tool rather than guessing at the contents from the filename.
+    """
+    content = "\n\n".join(pages)
+    non_ws_chars = len("".join(content.split()))
+    is_scanned = bool(pages) and non_ws_chars < 20 * len(pages)
+    if is_scanned:
+        return (
+            f"[File: {filename} — {len(pages)} pages, saved to {abs_path}]\n"
+            "No embedded text found; this PDF appears to be a scanned/image-only "
+            "document. If an OCR-capable tool is connected, use it to read this "
+            "file's content — do not guess at the contents from the filename alone."
+        )
+    if len(content) > max_chars:
+        content = content[:max_chars] + f"\n... [truncated, {len(pages)} pages total]"
+    return f"[File: {filename} — {len(pages)} pages, saved to {abs_path}]\n```\n{content}\n```"
+
+
 def _create_memory_backend(settings: Settings):  # type: ignore[return]
     """Factory: select and construct the configured memory backend."""
     if settings.memory_backend == "mcp":
@@ -594,13 +620,7 @@ async def _run_agent(settings: Settings) -> None:
                         doc = pymupdf.open(stream=raw_bytes, filetype="pdf")
                         pages = [page.get_text() for page in doc]
                         doc.close()
-                        content = "\n\n".join(pages)
-                        max_chars = 30_000
-                        if len(content) > max_chars:
-                            content = content[:max_chars] + f"\n... [truncated, {len(pages)} pages total]"
-                        file_parts.append(
-                            f"[File: {filename} — {len(pages)} pages, saved to {abs_path}]\n```\n{content}\n```"
-                        )
+                        file_parts.append(_format_pdf_attachment(pages, filename, abs_path))
                     except ImportError:
                         file_parts.append(
                             f"[File: {filename}] saved to {abs_path} "

--- a/src/pincer/cli.py
+++ b/src/pincer/cli.py
@@ -14,6 +14,7 @@ import contextlib
 import logging
 import os
 import socket
+import uuid
 from datetime import UTC
 from typing import TYPE_CHECKING, Any
 
@@ -167,14 +168,43 @@ def _format_pdf_attachment(pages: list[str], filename: str, abs_path: str, max_c
     is_scanned = bool(pages) and non_ws_chars < 20 * len(pages)
     if is_scanned:
         return (
-            f"[File: {filename} — {len(pages)} pages, saved to {abs_path}]\n"
+            f"[File: {filename} — {len(pages)} pages] saved to {abs_path}.\n"
             "No embedded text found; this PDF appears to be a scanned/image-only "
-            "document. If an OCR-capable tool is connected, use it to read this "
-            "file's content — do not guess at the contents from the filename alone."
+            "document (pages are images, not text). If the user wants its text "
+            f"read/extracted, call the OCR tool with file_path='{abs_path}' — "
+            "do not guess at the contents from the filename, and do not try to "
+            "transcribe it yourself."
         )
     if len(content) > max_chars:
         content = content[:max_chars] + f"\n... [truncated, {len(pages)} pages total]"
     return f"[File: {filename} — {len(pages)} pages, saved to {abs_path}]\n```\n{content}\n```"
+
+
+_IMAGE_EXTENSIONS = {
+    "image/jpeg": ".jpg",
+    "image/png": ".png",
+    "image/gif": ".gif",
+    "image/webp": ".webp",
+    "image/bmp": ".bmp",
+    "image/tiff": ".tiff",
+}
+
+
+def _format_image_attachment(filename: str, abs_path: str, size_bytes: int, media_type: str) -> str:
+    """Format an image attachment note for the LLM prompt.
+
+    Images have no text layer the model can inspect ahead of time, and unlike
+    a vision content block, an OCR tool needs a concrete argument (a file
+    path here) to act on — the model cannot regenerate the original bytes
+    from having merely "seen" the image. Give it that path directly, and
+    tell it not to transcribe the image itself via vision, which is slow
+    and produces nothing an OCR tool call can use.
+    """
+    return (
+        f"[Image: {filename}] saved to {abs_path} ({size_bytes} bytes, {media_type}).\n"
+        "If the user wants text read/extracted from this image, call the OCR tool "
+        f"with file_path='{abs_path}' — do not try to transcribe it yourself."
+    )
 
 
 def _create_memory_backend(settings: Settings):  # type: ignore[return]
@@ -432,6 +462,7 @@ async def _run_agent(settings: Settings) -> None:
                 config=mcp_cfg,
                 tool_registry=tools,
                 audit_logger=audit_logger,
+                local_upload_root=settings.data_dir / "workspace" / "uploads",
             )
             connection_results = await mcp_manager.start()
             for server_name, ok in connection_results.items():
@@ -642,6 +673,24 @@ async def _run_agent(settings: Settings) -> None:
 
             file_context = "\n\n".join(file_parts)
             text = f"{file_context}\n\n{text}" if text else file_context
+
+        # Handle image attachments — save to disk so an OCR-capable tool can
+        # be given a concrete file_path (mirrors the file-attachment saving
+        # above; images arrive without a filename, so one is generated).
+        if incoming.images:
+            uploads_dir = settings.data_dir / "workspace" / "uploads"
+            uploads_dir.mkdir(parents=True, exist_ok=True)
+
+            image_parts: list[str] = []
+            for raw_bytes, media_type in incoming.images:
+                ext = _IMAGE_EXTENSIONS.get(media_type, ".bin")
+                filename = f"image_{uuid.uuid4().hex[:8]}{ext}"
+                save_path = uploads_dir / filename
+                save_path.write_bytes(raw_bytes)
+                image_parts.append(_format_image_attachment(filename, str(save_path), len(raw_bytes), media_type))
+
+            image_context = "\n\n".join(image_parts)
+            text = f"{image_context}\n\n{text}" if text else image_context
 
         # The raw ID already on this message is the channel-native ID for
         # whoever we're replying to right now — guaranteed correct, and more

--- a/src/pincer/config/core.py
+++ b/src/pincer/config/core.py
@@ -39,6 +39,11 @@ class CoreSettings(BaseModel):
         default=None,
         description="Soft budget for the Available Skills prompt block; None disables truncation",
     )
+    mcp_instructions_max_chars: int = Field(
+        default=400,
+        ge=0,
+        description="Per-server truncation length for MCP server 'instructions' text surfaced in the system prompt",
+    )
 
     # ── Logging ───────────────────────────────────────────
     log_level: LogLevel = LogLevel.INFO

--- a/src/pincer/core/agent.py
+++ b/src/pincer/core/agent.py
@@ -764,7 +764,16 @@ class Agent:
                 servers = await self.mcp_manager.list_servers()
                 connected = [s for s in servers if s["connected"]]
                 if connected:
-                    server_lines = [f"  - {s['name']} ({s['tool_count']} tool(s))" for s in connected]
+                    max_chars = self._settings.mcp_instructions_max_chars
+                    server_lines = []
+                    for s in connected:
+                        server_lines.append(f"  - {s['name']} ({s['tool_count']} tool(s))")
+                        instructions = s.get("instructions")
+                        if instructions:
+                            collapsed = " ".join(instructions.split())
+                            if max_chars and len(collapsed) > max_chars:
+                                collapsed = collapsed[:max_chars] + "…"
+                            server_lines.append(f"    → {collapsed}")
                     base_prompt += "\n\n[Connected MCP servers — use their prefixed tools when relevant]\n" + "\n".join(
                         server_lines
                     )

--- a/src/pincer/core/agent.py
+++ b/src/pincer/core/agent.py
@@ -418,6 +418,13 @@ class Agent:
                     system=system_prompt,
                 )
                 last_response = response
+                # By the second iteration the model has already either
+                # committed to a tool call or produced final text — the
+                # image no longer needs to be resent (and, unlike text,
+                # isn't persisted across turns anyway; see LLMMessage.to_dict).
+                # Cuts vision re-ingestion cost on every retry within this loop.
+                if user_msg.images:
+                    user_msg.images = []
             except BudgetExceededError:
                 final_text = (
                     "Warning: Daily budget limit reached. "
@@ -622,6 +629,10 @@ class Agent:
                     tools=tool_schemas,
                     system=system_prompt,
                 )
+                # See handle_message: drop the image after the first
+                # completion so later retries in this loop don't resend it.
+                if user_msg.images:
+                    user_msg.images = []
             except BudgetExceededError:
                 yield StreamChunk(StreamEventType.DONE, "Daily budget limit reached.")
                 return

--- a/src/pincer/mcp/bridge.py
+++ b/src/pincer/mcp/bridge.py
@@ -10,10 +10,14 @@ For each tool discovered on an MCP server, creates an async callable that:
 
 from __future__ import annotations
 
+import base64
 import fnmatch
 import logging
 import uuid
+from pathlib import Path
 from typing import TYPE_CHECKING, Any
+
+from pincer.mcp.config import MCPTransport
 
 if TYPE_CHECKING:
     from pincer.mcp.audit import MCPAuditLogger
@@ -88,6 +92,41 @@ def _format_result(result: Any) -> str:
     return "\n".join(parts) if parts else "(empty response)"
 
 
+def _inline_local_file_paths(value: Any, upload_root: Path) -> Any:
+    """Recursively replace ``file_path`` arguments pointing inside our own
+    local upload cache with inline ``image_b64`` content.
+
+    Needed only for HTTP-transport MCP servers: they run in a separate,
+    isolated container/process with no shared filesystem, so a ``file_path``
+    the model copied from an attachment hint (see cli.py's image/PDF
+    attachment handling) would point at a path that doesn't exist on the
+    server's side. This is the local-disk fallback for when no shared
+    object-storage bridge (e.g. S3/MinIO) is configured — a stdio server
+    never needs this since it already shares Pincer's filesystem directly.
+
+    Scoped strictly to paths under ``upload_root`` (never arbitrary
+    filesystem paths) so a compromised or hallucinating tool call can't be
+    used to read and exfiltrate unrelated local files through this
+    "helpful" substitution.
+    """
+    if isinstance(value, dict):
+        if isinstance(value.get("file_path"), str) and "image_b64" not in value:
+            candidate = Path(value["file_path"])
+            try:
+                resolved = candidate.resolve()
+                in_upload_root = resolved.is_relative_to(upload_root.resolve())
+            except (OSError, ValueError):
+                in_upload_root = False
+            if in_upload_root and resolved.is_file():
+                inlined = {k: v for k, v in value.items() if k != "file_path"}
+                inlined["image_b64"] = base64.b64encode(resolved.read_bytes()).decode()
+                return inlined
+        return {k: _inline_local_file_paths(v, upload_root) for k, v in value.items()}
+    if isinstance(value, list):
+        return [_inline_local_file_paths(v, upload_root) for v in value]
+    return value
+
+
 class MCPToolBridge:
     """
     Bridges MCP tools into Pincer's tool registry.
@@ -103,12 +142,17 @@ class MCPToolBridge:
         audit_logger: MCPAuditLogger,
         prefix: bool = True,
         security_gate: MCPSecurityGate | None = None,
+        local_upload_root: Path | None = None,
     ) -> None:
         self.session = session
         self.tool_registry = tool_registry
         self.audit_logger = audit_logger
         self.prefix = prefix
         self.security_gate = security_gate
+        # Pincer's own local attachment cache (settings.data_dir/workspace/uploads).
+        # Used to inline file_path arguments as base64 for HTTP-transport
+        # servers — see _inline_local_file_paths.
+        self.local_upload_root = local_upload_root
         self._registered_names: list[str] = []
 
     def register_tools(self) -> int:
@@ -180,6 +224,7 @@ class MCPToolBridge:
         session = self.session
         audit = self.audit_logger
         security = self.security_gate
+        upload_root = self.local_upload_root
 
         async def handler(context: dict[str, Any] | None = None, **kwargs: Any) -> str:
             identity = (context or {}).get("user_id")
@@ -187,6 +232,9 @@ class MCPToolBridge:
             # Rate limiting
             if security and not security.check_rate_limit(session.name, mcp_name):
                 return f"[RateLimited] Too many calls to {session.name}::{mcp_name} — slow down"
+
+            if upload_root is not None and session.config.transport == MCPTransport.STREAMABLE_HTTP:
+                kwargs = _inline_local_file_paths(kwargs, upload_root)
 
             call_key = str(uuid.uuid4())
             audit.start_call(session.name, mcp_name, call_key)

--- a/src/pincer/mcp/client.py
+++ b/src/pincer/mcp/client.py
@@ -41,6 +41,7 @@ class MCPClientSession:
         self._connect_attempts = 0
         self._tmpdir: str | None = None
         self._sandbox: MCPSandbox | None = None
+        self._instructions: str | None = None
         # Set via set_notification_handler() — may be attached before or after
         # connect(), since the server-to-client push this feeds (e.g. ms365-mcp's
         # delayed auth-completion message) can arrive minutes after connection.
@@ -77,6 +78,13 @@ class MCPClientSession:
     @property
     def tools(self) -> list[Any]:
         return self._tools
+
+    @property
+    def instructions(self) -> str | None:
+        """The server's self-reported usage instructions from the MCP handshake
+        (`InitializeResult.instructions`), surfaced to the agent's system prompt
+        alongside the server's tool list — see MCPClientManager.list_servers()."""
+        return self._instructions
 
     async def connect(self) -> None:
         """Establish connection and initialize MCP session."""
@@ -117,7 +125,8 @@ class MCPClientSession:
             # first launch need a much longer window here without slowing down every
             # subsequent tool call.
             with anyio.fail_after(self.config.startup_timeout):
-                await self._session.initialize()
+                init_result = await self._session.initialize()
+                self._instructions = init_result.instructions
                 await self._discover_tools()
 
             self._connected = True
@@ -348,6 +357,7 @@ class MCPClientSession:
     async def _cleanup(self) -> None:
         self._connected = False
         self._session = None
+        self._instructions = None
         if self._exit_stack:
             with contextlib.suppress(Exception):
                 await self._exit_stack.aclose()

--- a/src/pincer/mcp/manager.py
+++ b/src/pincer/mcp/manager.py
@@ -22,6 +22,7 @@ from pincer.mcp.client import MCPClientSession
 
 if TYPE_CHECKING:
     from collections.abc import Awaitable, Callable
+    from pathlib import Path
 
     from mcp.types import LoggingMessageNotificationParams
 
@@ -52,11 +53,15 @@ class MCPClientManager:
         tool_registry: ToolRegistry,
         audit_logger: AuditLogger | None = None,
         security_gate: MCPSecurityGate | None = None,
+        local_upload_root: Path | None = None,
     ) -> None:
         self.config = config
         self.tool_registry = tool_registry
         self._audit = MCPAuditLogger(audit_logger, security_gate)
         self._security_gate = security_gate
+        # Passed through to every MCPToolBridge — lets HTTP-transport servers
+        # receive local attachments as inline base64 (see bridge.py).
+        self._local_upload_root = local_upload_root
         self._sessions: dict[str, MCPClientSession] = {}
         self._bridges: dict[str, MCPToolBridge] = {}
         self._task_group: anyio.abc.TaskGroup | None = None
@@ -117,6 +122,7 @@ class MCPClientManager:
                 audit_logger=self._audit,
                 prefix=self.config.tool_prefix,
                 security_gate=self._security_gate,
+                local_upload_root=self._local_upload_root,
             )
             bridge.register_tools()
             self._bridges[srv_config.name] = bridge
@@ -244,6 +250,7 @@ class MCPClientManager:
                     audit_logger=self._audit,
                     prefix=self.config.tool_prefix,
                     security_gate=self._security_gate,
+                    local_upload_root=self._local_upload_root,
                 )
                 bridge.register_tools()
                 self._bridges[name] = bridge

--- a/src/pincer/mcp/manager.py
+++ b/src/pincer/mcp/manager.py
@@ -175,6 +175,7 @@ class MCPClientManager:
                     "enabled": srv.enabled,
                     "connected": session.connected if session else False,
                     "tool_count": len(session.tools) if session else 0,
+                    "instructions": session.instructions if session else None,
                     "disabled": srv.name in self._disabled,
                     "sandbox": srv.sandbox,
                     "approval_required": srv.approval_required,

--- a/tests/test_cli_image_attachment.py
+++ b/tests/test_cli_image_attachment.py
@@ -1,0 +1,32 @@
+"""Tests for _format_image_attachment — the file_path hint injected into the
+LLM prompt for uploaded images, so an OCR-capable MCP tool has a concrete
+argument to act on instead of the model trying to transcribe the image via
+its own vision."""
+
+from __future__ import annotations
+
+from pincer.cli import _IMAGE_EXTENSIONS, _format_image_attachment
+
+
+def test_hint_includes_saved_path_and_size() -> None:
+    result = _format_image_attachment("image_ab12cd34.png", "/data/uploads/image_ab12cd34.png", 4096, "image/png")
+    assert "/data/uploads/image_ab12cd34.png" in result
+    assert "4096 bytes" in result
+    assert "image/png" in result
+
+
+def test_hint_tells_model_to_use_file_path_not_transcribe() -> None:
+    result = _format_image_attachment("photo.jpg", "/data/uploads/photo.jpg", 100, "image/jpeg")
+    assert "file_path='/data/uploads/photo.jpg'" in result
+    assert "do not try to transcribe it yourself" in result
+
+
+def test_common_image_media_types_map_to_expected_extensions() -> None:
+    assert _IMAGE_EXTENSIONS["image/jpeg"] == ".jpg"
+    assert _IMAGE_EXTENSIONS["image/png"] == ".png"
+    assert _IMAGE_EXTENSIONS["image/webp"] == ".webp"
+
+
+def test_unknown_media_type_falls_back_to_bin_extension() -> None:
+    # cli.py looks this up as _IMAGE_EXTENSIONS.get(media_type, ".bin")
+    assert _IMAGE_EXTENSIONS.get("image/heic", ".bin") == ".bin"

--- a/tests/test_cli_pdf_attachment.py
+++ b/tests/test_cli_pdf_attachment.py
@@ -1,0 +1,61 @@
+"""Tests for _format_pdf_attachment — the scanned/image-only PDF detection
+heuristic in cli.py's automatic PDF-attachment text extraction."""
+
+from __future__ import annotations
+
+from pincer.cli import _format_pdf_attachment
+
+
+def test_normal_text_pdf_returns_code_fence() -> None:
+    pages = ["This is a real page of extracted text with plenty of content. " * 5]
+    result = _format_pdf_attachment(pages, "report.pdf", "/data/uploads/report.pdf")
+    assert "```" in result
+    assert "This is a real page" in result
+    assert "scanned" not in result
+
+
+def test_scanned_pdf_all_pages_empty_flags_no_text() -> None:
+    pages = ["", "", ""]
+    result = _format_pdf_attachment(pages, "scan.pdf", "/data/uploads/scan.pdf")
+    assert "scanned/image-only" in result
+    assert "```" not in result
+    assert "3 pages" in result
+
+
+def test_scanned_pdf_whitespace_only_pages_flags_no_text() -> None:
+    """pymupdf commonly returns form-feed/whitespace artifacts, not truly empty strings."""
+    pages = ["\n\n\x0c", "   \n", "\x0c"]
+    result = _format_pdf_attachment(pages, "scan.pdf", "/data/uploads/scan.pdf")
+    assert "scanned/image-only" in result
+
+
+def test_single_blank_page_among_text_pages_does_not_trigger_scanned_path() -> None:
+    """One blank page (e.g. a divider) in an otherwise text-rich document must not
+    be misclassified — the heuristic averages across all pages."""
+    text_page = "Real extracted paragraph text with plenty of words in it. " * 10
+    pages = [text_page, "", text_page]
+    result = _format_pdf_attachment(pages, "mixed.pdf", "/data/uploads/mixed.pdf")
+    assert "```" in result
+    assert "scanned" not in result
+
+
+def test_short_but_real_single_page_pdf_does_not_trigger_scanned_path() -> None:
+    """A short but genuinely non-empty single-page PDF (e.g. a cover page)
+    should not be misclassified as scanned."""
+    pages = ["Confidential — Draft v3 — Do not distribute"]
+    result = _format_pdf_attachment(pages, "cover.pdf", "/data/uploads/cover.pdf")
+    assert "```" in result
+    assert "scanned" not in result
+
+
+def test_empty_document_no_pages_does_not_crash() -> None:
+    result = _format_pdf_attachment([], "empty.pdf", "/data/uploads/empty.pdf")
+    assert "0 pages" in result
+    assert "scanned" not in result
+
+
+def test_long_content_is_truncated() -> None:
+    pages = ["word " * 20_000]
+    result = _format_pdf_attachment(pages, "huge.pdf", "/data/uploads/huge.pdf", max_chars=100)
+    assert "truncated" in result
+    assert "1 pages total" in result

--- a/tests/test_cli_pdf_attachment.py
+++ b/tests/test_cli_pdf_attachment.py
@@ -59,3 +59,18 @@ def test_long_content_is_truncated() -> None:
     result = _format_pdf_attachment(pages, "huge.pdf", "/data/uploads/huge.pdf", max_chars=100)
     assert "truncated" in result
     assert "1 pages total" in result
+
+
+def test_scanned_pdf_gives_explicit_ocr_tool_call_syntax() -> None:
+    """A scanned PDF must be handed to the OCR tool the same way a plain
+    image attachment is — with a concrete file_path argument, not a vague
+    'use an OCR tool' hint the model has to guess how to act on."""
+    pages = ["", "", ""]
+    result = _format_pdf_attachment(pages, "scan.pdf", "/data/uploads/scan.pdf")
+    assert "file_path='/data/uploads/scan.pdf'" in result
+
+
+def test_scanned_pdf_warns_against_self_transcription() -> None:
+    pages = ["", "", ""]
+    result = _format_pdf_attachment(pages, "scan.pdf", "/data/uploads/scan.pdf")
+    assert "do not try to transcribe it yourself" in result

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -36,6 +36,8 @@ def test_settings_no_providers_raises(tmp_path: Path) -> None:
             default_provider="anthropic",
             anthropic_api_key="",  # type: ignore[arg-type]
             openai_api_key="",  # type: ignore[arg-type]
+            openai_compatible_base_url="",
+            anthropic_compatible_base_url="",
             data_dir=tmp_path,
             _env_file=None,  # hermetic: ignore the developer's .env  # type: ignore[call-arg]
         )

--- a/tests/test_mcp_agent_integration.py
+++ b/tests/test_mcp_agent_integration.py
@@ -14,6 +14,7 @@ def _make_agent():
     settings.max_tool_iterations = 5
     settings.default_provider = MagicMock(value="anthropic")
     settings.daily_budget_usd = 10.0
+    settings.mcp_instructions_max_chars = 400
 
     llm = MagicMock()
     session_mgr = MagicMock()
@@ -102,6 +103,76 @@ async def test_build_system_prompt_mcp_no_connected_servers():
 
     prompt = await agent._build_system_prompt("user1", "hello")
     assert "[Connected MCP servers" not in prompt
+
+
+async def test_build_system_prompt_includes_server_instructions():
+    """A connected server's instructions text appears under its name/tool_count line."""
+    agent = _make_agent()
+    manager = MagicMock()
+    manager.list_servers = AsyncMock(
+        return_value=[
+            {
+                "name": "doctr",
+                "connected": True,
+                "tool_count": 6,
+                "instructions": "Use ocr_document_text for a quick plain-text read of an image or PDF.",
+            },
+        ]
+    )
+    agent.mcp_manager = manager
+
+    prompt = await agent._build_system_prompt("user1", "hello")
+    assert "doctr (6 tool(s))" in prompt
+    assert "Use ocr_document_text for a quick plain-text read of an image or PDF." in prompt
+
+
+async def test_build_system_prompt_missing_instructions_key_is_backward_compatible():
+    """Server dicts without an 'instructions' key (older shape) must not crash or add a stray line."""
+    agent = _make_agent()
+    agent.mcp_manager = _make_mcp_manager(connected=True)
+
+    prompt = await agent._build_system_prompt("user1", "hello")
+    assert "github (5 tool(s))" in prompt
+    assert "→" not in prompt
+
+
+async def test_build_system_prompt_none_instructions_adds_no_line():
+    """A server with instructions=None gets no follow-up line, no crash."""
+    agent = _make_agent()
+    manager = MagicMock()
+    manager.list_servers = AsyncMock(
+        return_value=[
+            {"name": "quiet", "connected": True, "tool_count": 1, "instructions": None},
+        ]
+    )
+    agent.mcp_manager = manager
+
+    prompt = await agent._build_system_prompt("user1", "hello")
+    assert "quiet (1 tool(s))" in prompt
+    assert "→" not in prompt
+
+
+async def test_build_system_prompt_truncates_long_instructions():
+    """Instructions longer than mcp_instructions_max_chars are truncated with an ellipsis."""
+    agent = _make_agent()
+    agent._settings.mcp_instructions_max_chars = 20
+    manager = MagicMock()
+    manager.list_servers = AsyncMock(
+        return_value=[
+            {
+                "name": "verbose",
+                "connected": True,
+                "tool_count": 1,
+                "instructions": "This is a very long instructions string that exceeds the configured cap.",
+            },
+        ]
+    )
+    agent.mcp_manager = manager
+
+    prompt = await agent._build_system_prompt("user1", "hello")
+    assert "This is a very long" in prompt
+    assert "…" in prompt
+    assert "exceeds the configured cap" not in prompt
 
 
 async def test_build_system_prompt_mcp_list_servers_error_is_silent():

--- a/tests/test_mcp_auth.py
+++ b/tests/test_mcp_auth.py
@@ -17,7 +17,7 @@ def _make_provider(**kwargs) -> MCPAuthProvider:
             {"client_id": "claude-desktop", "client_secret": "secret123", "name": "Claude Desktop"},
         ],
     )
-    return MCPAuthProvider(allowed_clients=clients, signing_key="test-signing-key", **kwargs)
+    return MCPAuthProvider(allowed_clients=clients, signing_key="test-signing-key-32-bytes-long!!", **kwargs)
 
 
 # ── Token issuance ─────────────────────────────────────────────────────────────
@@ -72,7 +72,7 @@ def test_validate_token_expired():
         "exp": int(time.time()) - 3600,
         "jti": "expiredtoken",
     }
-    expired_token = pyjwt.encode(expired_payload, "test-signing-key", algorithm="HS256")
+    expired_token = pyjwt.encode(expired_payload, "test-signing-key-32-bytes-long!!", algorithm="HS256")
     assert provider.validate_token(expired_token) is None
 
 
@@ -128,7 +128,7 @@ def test_auto_generate_secret_if_not_provided():
     """A client without a pre-set secret gets one auto-generated."""
     provider = MCPAuthProvider(
         allowed_clients=[{"client_id": "auto-client"}],
-        signing_key="test-key",
+        signing_key="test-signing-key-32-bytes-long!!",
     )
     client = provider._clients["auto-client"]
     assert len(client.client_secret) > 10

--- a/tests/test_mcp_bridge.py
+++ b/tests/test_mcp_bridge.py
@@ -2,11 +2,19 @@
 
 from __future__ import annotations
 
+import base64
 from dataclasses import dataclass, field
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock
 
-from pincer.mcp.bridge import MCPToolBridge, _convert_schema, _format_result, _requires_approval
+from pincer.mcp.bridge import (
+    MCPToolBridge,
+    _convert_schema,
+    _format_result,
+    _inline_local_file_paths,
+    _requires_approval,
+)
+from pincer.mcp.config import MCPTransport
 
 # ── Helpers / stubs ──────────────────────────────────────────────────────────
 
@@ -48,6 +56,7 @@ def _make_session(tools: list[FakeTool], server_name: str = "testserver"):
     session.tools = tools
     session.config = MagicMock()
     session.config.approval_required = ["*"]
+    session.config.transport = MCPTransport.STDIO
     session.connected = True
     return session
 
@@ -509,3 +518,148 @@ def test_collision_no_prefix_blocked() -> None:
 
     assert count == 0
     assert registry.list_tools() == ["shared_tool"]
+
+
+# ── Local file_path → image_b64 inlining (HTTP-transport fallback) ──────────
+
+
+def test_inline_swaps_file_path_for_base64_when_in_upload_root(tmp_path) -> None:
+    upload_root = tmp_path / "uploads"
+    upload_root.mkdir()
+    saved = upload_root / "image_ab12cd34.png"
+    saved.write_bytes(b"fake png bytes")
+
+    kwargs = {"params": {"source": {"file_path": str(saved)}}}
+    result = _inline_local_file_paths(kwargs, upload_root)
+
+    source = result["params"]["source"]
+    assert "file_path" not in source
+    assert base64.b64decode(source["image_b64"]) == b"fake png bytes"
+
+
+def test_inline_leaves_paths_outside_upload_root_untouched(tmp_path) -> None:
+    """A path outside our own cache is left alone — never read or forwarded
+    as base64 — so a compromised/hallucinating tool call can't be used to
+    exfiltrate arbitrary local files."""
+    upload_root = tmp_path / "uploads"
+    upload_root.mkdir()
+    outside = tmp_path / "secret.txt"
+    outside.write_bytes(b"do not leak me")
+
+    kwargs = {"params": {"source": {"file_path": str(outside)}}}
+    result = _inline_local_file_paths(kwargs, upload_root)
+
+    assert result["params"]["source"]["file_path"] == str(outside)
+    assert "image_b64" not in result["params"]["source"]
+
+
+def test_inline_leaves_nonexistent_path_untouched(tmp_path) -> None:
+    upload_root = tmp_path / "uploads"
+    upload_root.mkdir()
+    missing = upload_root / "does_not_exist.png"
+
+    kwargs = {"params": {"source": {"file_path": str(missing)}}}
+    result = _inline_local_file_paths(kwargs, upload_root)
+
+    assert result["params"]["source"]["file_path"] == str(missing)
+    assert "image_b64" not in result["params"]["source"]
+
+
+def test_inline_handles_list_of_sources(tmp_path) -> None:
+    """recognize_text's `images: list[ImageSource]` shape."""
+    upload_root = tmp_path / "uploads"
+    upload_root.mkdir()
+    saved = upload_root / "crop.png"
+    saved.write_bytes(b"crop bytes")
+
+    kwargs = {"params": {"images": [{"file_path": str(saved)}]}}
+    result = _inline_local_file_paths(kwargs, upload_root)
+
+    inlined = result["params"]["images"][0]
+    assert "file_path" not in inlined
+    assert base64.b64decode(inlined["image_b64"]) == b"crop bytes"
+
+
+def test_inline_skips_when_image_b64_already_present(tmp_path) -> None:
+    upload_root = tmp_path / "uploads"
+    upload_root.mkdir()
+    saved = upload_root / "image.png"
+    saved.write_bytes(b"bytes")
+
+    kwargs = {"source": {"file_path": str(saved), "image_b64": "already-set"}}
+    result = _inline_local_file_paths(kwargs, upload_root)
+
+    assert result["source"]["file_path"] == str(saved)
+    assert result["source"]["image_b64"] == "already-set"
+
+
+async def test_handler_inlines_file_path_for_http_transport(tmp_path) -> None:
+    """An HTTP-transport server (isolated container, no shared filesystem)
+    gets the locally-cached file read and forwarded as base64 instead of a
+    file_path it could never resolve on its own side."""
+    upload_root = tmp_path / "uploads"
+    upload_root.mkdir()
+    saved = upload_root / "scan.png"
+    saved.write_bytes(b"scan bytes")
+
+    tool = FakeTool("ocr_document_text")
+    session = _make_session([tool])
+    session.config.approval_required = ["none"]
+    session.config.transport = MCPTransport.STREAMABLE_HTTP
+    session.call_tool = AsyncMock(return_value=FakeCallToolResult(content=[FakeTextContent(text="ocr result")]))
+
+    registry = _make_registry()
+    audit = _make_audit()
+    bridge = MCPToolBridge(session, registry, audit, prefix=True, local_upload_root=upload_root)
+    bridge.register_tools()
+
+    await registry.execute("testserver__ocr_document_text", {"params": {"source": {"file_path": str(saved)}}})
+
+    called_kwargs = session.call_tool.call_args.args[1]
+    source = called_kwargs["params"]["source"]
+    assert "file_path" not in source
+    assert base64.b64decode(source["image_b64"]) == b"scan bytes"
+
+
+async def test_handler_leaves_file_path_untouched_for_stdio_transport(tmp_path) -> None:
+    """stdio servers already share Pincer's filesystem directly — inlining
+    would be pure overhead (and unnecessary base64 bloat) with no benefit."""
+    upload_root = tmp_path / "uploads"
+    upload_root.mkdir()
+    saved = upload_root / "scan.png"
+    saved.write_bytes(b"scan bytes")
+
+    tool = FakeTool("ocr_document_text")
+    session = _make_session([tool])
+    session.config.approval_required = ["none"]
+    session.config.transport = MCPTransport.STDIO
+    session.call_tool = AsyncMock(return_value=FakeCallToolResult(content=[FakeTextContent(text="ocr result")]))
+
+    registry = _make_registry()
+    audit = _make_audit()
+    bridge = MCPToolBridge(session, registry, audit, prefix=True, local_upload_root=upload_root)
+    bridge.register_tools()
+
+    await registry.execute("testserver__ocr_document_text", {"params": {"source": {"file_path": str(saved)}}})
+
+    called_kwargs = session.call_tool.call_args.args[1]
+    assert called_kwargs["params"]["source"]["file_path"] == str(saved)
+
+
+async def test_handler_leaves_kwargs_untouched_when_no_upload_root_configured() -> None:
+    """local_upload_root defaults to None — no-op unless cli.py wires it up."""
+    tool = FakeTool("ocr_document_text")
+    session = _make_session([tool])
+    session.config.approval_required = ["none"]
+    session.config.transport = MCPTransport.STREAMABLE_HTTP
+    session.call_tool = AsyncMock(return_value=FakeCallToolResult(content=[FakeTextContent(text="ocr result")]))
+
+    registry = _make_registry()
+    audit = _make_audit()
+    bridge = MCPToolBridge(session, registry, audit, prefix=True)  # no local_upload_root
+    bridge.register_tools()
+
+    await registry.execute("testserver__ocr_document_text", {"params": {"source": {"file_path": "/some/path"}}})
+
+    called_kwargs = session.call_tool.call_args.args[1]
+    assert called_kwargs["params"]["source"]["file_path"] == "/some/path"

--- a/tests/test_mcp_client.py
+++ b/tests/test_mcp_client.py
@@ -196,8 +196,8 @@ async def test_connect_passes_handle_notification_as_logging_callback() -> None:
         async def __aexit__(self, *exc: object) -> bool:
             return False
 
-        async def initialize(self) -> None:
-            pass
+        async def initialize(self) -> MagicMock:
+            return MagicMock(instructions=None)
 
         async def list_tools(self) -> MagicMock:
             return MagicMock(tools=[])
@@ -212,6 +212,87 @@ async def test_connect_passes_handle_notification_as_logging_callback() -> None:
         await session.connect()
 
     assert captured_kwargs.get("logging_callback") == session._handle_notification
+
+
+# ── instructions ──────────────────────────────────────────────────────────────
+
+
+async def test_connect_captures_server_instructions() -> None:
+    """connect() must capture InitializeResult.instructions from the handshake."""
+    cfg = _make_stdio_config(sandbox=False)
+    session = MCPClientSession(cfg)
+    assert session.instructions is None
+
+    class _FakeClientSession:
+        def __init__(self, read_stream: object, write_stream: object, **kwargs: object) -> None:
+            pass
+
+        async def __aenter__(self) -> _FakeClientSession:
+            return self
+
+        async def __aexit__(self, *exc: object) -> bool:
+            return False
+
+        async def initialize(self) -> MagicMock:
+            return MagicMock(instructions="Use ocr_document_text for a quick plain-text read.")
+
+        async def list_tools(self) -> MagicMock:
+            return MagicMock(tools=[])
+
+    async def _fake_connect_stdio(*args: object, **kwargs: object) -> tuple[MagicMock, MagicMock]:
+        return MagicMock(), MagicMock()
+
+    with (
+        patch("mcp.ClientSession", _FakeClientSession),
+        patch("pincer.mcp.client.MCPClientSession._connect_stdio", _fake_connect_stdio),
+    ):
+        await session.connect()
+
+    assert session.instructions == "Use ocr_document_text for a quick plain-text read."
+
+
+async def test_connect_captures_none_instructions() -> None:
+    """A server that reports no instructions leaves .instructions as None, not an error."""
+    cfg = _make_stdio_config(sandbox=False)
+    session = MCPClientSession(cfg)
+
+    class _FakeClientSession:
+        def __init__(self, read_stream: object, write_stream: object, **kwargs: object) -> None:
+            pass
+
+        async def __aenter__(self) -> _FakeClientSession:
+            return self
+
+        async def __aexit__(self, *exc: object) -> bool:
+            return False
+
+        async def initialize(self) -> MagicMock:
+            return MagicMock(instructions=None)
+
+        async def list_tools(self) -> MagicMock:
+            return MagicMock(tools=[])
+
+    async def _fake_connect_stdio(*args: object, **kwargs: object) -> tuple[MagicMock, MagicMock]:
+        return MagicMock(), MagicMock()
+
+    with (
+        patch("mcp.ClientSession", _FakeClientSession),
+        patch("pincer.mcp.client.MCPClientSession._connect_stdio", _fake_connect_stdio),
+    ):
+        await session.connect()
+
+    assert session.instructions is None
+
+
+async def test_cleanup_resets_instructions() -> None:
+    """disconnect() must clear instructions so a stale value can't leak into a reconnect."""
+    cfg = _make_stdio_config(sandbox=False)
+    session = MCPClientSession(cfg)
+    session._instructions = "stale instructions from a previous connection"
+
+    await session._cleanup()
+
+    assert session.instructions is None
 
 
 # ── Health check ──────────────────────────────────────────────────────────────

--- a/tests/test_mcp_manager.py
+++ b/tests/test_mcp_manager.py
@@ -172,6 +172,37 @@ async def test_list_servers_includes_all_configured() -> None:
     # Not connected yet → all show False
     for s in statuses:
         assert s["connected"] is False
+        assert s["instructions"] is None
+
+
+async def test_list_servers_propagates_connected_session_instructions() -> None:
+    cfg = _make_config("srv")
+    manager = _make_manager(cfg)
+
+    mock_session = MagicMock()
+    mock_session.connected = True
+    mock_session.tools = []
+    mock_session.instructions = "Use ocr_document_text for a quick plain-text read."
+    manager._sessions["srv"] = mock_session
+
+    statuses = await manager.list_servers()
+    by_name = {s["name"]: s for s in statuses}
+    assert by_name["srv"]["instructions"] == "Use ocr_document_text for a quick plain-text read."
+
+
+async def test_list_servers_instructions_none_for_connected_session_without_them() -> None:
+    cfg = _make_config("srv")
+    manager = _make_manager(cfg)
+
+    mock_session = MagicMock()
+    mock_session.connected = True
+    mock_session.tools = []
+    mock_session.instructions = None
+    manager._sessions["srv"] = mock_session
+
+    statuses = await manager.list_servers()
+    by_name = {s["name"]: s for s in statuses}
+    assert by_name["srv"]["instructions"] is None
 
 
 # ── Reconnection ──────────────────────────────────────────────────────────────

--- a/tests/test_mcp_security_integration.py
+++ b/tests/test_mcp_security_integration.py
@@ -14,7 +14,7 @@ def test_oauth_flow_issue_and_validate():
         allowed_clients=[
             {"client_id": "cursor", "client_secret": "cursor-secret", "name": "Cursor IDE"},
         ],
-        signing_key="integration-test-key",
+        signing_key="integration-test-signing-key-32-bytes!!",
         token_expiry_seconds=3600,
     )
 
@@ -33,7 +33,7 @@ def test_oauth_flow_issue_and_validate():
 
 def test_remote_client_without_oauth_not_localhost():
     """Non-localhost address correctly identified as requiring auth."""
-    provider = MCPAuthProvider(allowed_clients=[], signing_key="k")
+    provider = MCPAuthProvider(allowed_clients=[], signing_key="test-signing-key-32-bytes-long!!")
     assert provider.is_localhost("10.0.0.5") is False
     assert provider.is_localhost("172.16.0.1") is False
 

--- a/uv.lock
+++ b/uv.lock
@@ -4,20 +4,25 @@ requires-python = ">=3.12"
 resolution-markers = [
     "python_full_version >= '3.15' and sys_platform == 'win32'",
     "python_full_version >= '3.15' and sys_platform == 'emscripten'",
-    "python_full_version >= '3.15' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version >= '3.15' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version >= '3.15' and sys_platform == 'darwin'",
     "python_full_version == '3.14.*' and sys_platform == 'win32'",
     "python_full_version == '3.14.*' and sys_platform == 'emscripten'",
-    "python_full_version == '3.14.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version == '3.14.*' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version == '3.14.*' and sys_platform == 'darwin'",
     "python_full_version == '3.13.*' and sys_platform == 'win32'",
     "python_full_version == '3.13.*' and sys_platform == 'emscripten'",
-    "python_full_version == '3.13.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version == '3.13.*' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version == '3.13.*' and sys_platform == 'darwin'",
     "python_full_version < '3.13' and sys_platform == 'win32'",
     "python_full_version < '3.13' and sys_platform == 'emscripten'",
-    "python_full_version < '3.13' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version < '3.13' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version < '3.13' and sys_platform == 'darwin'",
 ]
 
 [manifest]
 members = [
+    "doctr-mcp",
     "ms365-mcp",
     "pincer-agent",
     "pincer-mcps",
@@ -260,6 +265,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/14/93/f66ea8bfe39f2e6bb9da8e27fa5457ad2520e8f7612dfc547b17fad55c4d/anthropic-0.97.0.tar.gz", hash = "sha256:021e79fd8e21e90ad94dc5ba2bbbd8b1599f424f5b1fab6c06204009cab764be", size = 669502, upload-time = "2026-04-23T20:52:34.445Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/53/b6/8e851369fa661ad0fef2ae6266bf3b7d52b78ccf011720058f4adaca59e2/anthropic-0.97.0-py3-none-any.whl", hash = "sha256:8a1a472dfabcfc0c52ff6a3eecf724ac7e07107a2f6e2367be55ceb42f5d5613", size = 662126, upload-time = "2026-04-23T20:52:32.377Z" },
+]
+
+[[package]]
+name = "anyascii"
+version = "0.3.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/db/ba/edebda727008390936da4a9bf677c19cd63b32d51e864656d2cbd1028e25/anyascii-0.3.3.tar.gz", hash = "sha256:c94e9dd9d47b3d9494eca305fef9447d00b4bf1a32aff85aa746fa3ec7fb95c3", size = 264680, upload-time = "2025-06-29T03:33:30.427Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c2/76/783b75a21ce3563b8709050de030ae253853b147bd52e141edc1025aa268/anyascii-0.3.3-py3-none-any.whl", hash = "sha256:f5ab5e53c8781a36b5a40e1296a0eeda2f48c649ef10c3921c1381b1d00dee7a", size = 345090, upload-time = "2025-06-29T03:33:28.356Z" },
 ]
 
 [[package]]
@@ -1011,6 +1025,56 @@ wheels = [
 ]
 
 [[package]]
+name = "doctr-mcp"
+version = "0.1.0"
+source = { editable = "src/doctr-mcp" }
+dependencies = [
+    { name = "fastmcp" },
+    { name = "pillow" },
+    { name = "pydantic" },
+    { name = "pydantic-settings" },
+    { name = "python-doctr" },
+    { name = "starlette" },
+    { name = "torch", version = "2.13.0", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform == 'darwin'" },
+    { name = "torch", version = "2.13.0+cpu", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "sys_platform != 'darwin'" },
+    { name = "torchvision", version = "0.28.0", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform == 'darwin'" },
+    { name = "torchvision", version = "0.28.0+cpu", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "sys_platform != 'darwin'" },
+    { name = "uvicorn", extra = ["standard"] },
+]
+
+[package.optional-dependencies]
+dev = [
+    { name = "httpx" },
+    { name = "pytest" },
+    { name = "pytest-asyncio" },
+    { name = "pytest-cov" },
+]
+telemetry = [
+    { name = "pincer-telemetry" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "fastmcp", specifier = "==3.2.4" },
+    { name = "httpx", marker = "extra == 'dev'", specifier = ">=0.27.0" },
+    { name = "pillow", specifier = ">=10.1.0" },
+    { name = "pincer-telemetry", marker = "extra == 'telemetry'", git = "https://github.com/pincerhq/pincer-telemetry.git?rev=main" },
+    { name = "pydantic", specifier = ">=2.4.1,<3.0" },
+    { name = "pydantic-settings", specifier = ">=2.0.0" },
+    { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.3.0" },
+    { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.24.0" },
+    { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=6.0.0" },
+    { name = "python-doctr", specifier = "==1.0.1" },
+    { name = "starlette", specifier = ">=0.41.0" },
+    { name = "torch", marker = "sys_platform != 'darwin'", specifier = ">=2.0.0,<3.0.0", index = "https://download.pytorch.org/whl/cpu" },
+    { name = "torch", marker = "sys_platform == 'darwin'", specifier = ">=2.0.0,<3.0.0" },
+    { name = "torchvision", marker = "sys_platform != 'darwin'", specifier = ">=0.15.0", index = "https://download.pytorch.org/whl/cpu" },
+    { name = "torchvision", marker = "sys_platform == 'darwin'", specifier = ">=0.15.0" },
+    { name = "uvicorn", extras = ["standard"], specifier = ">=0.34.0" },
+]
+provides-extras = ["telemetry", "dev"]
+
+[[package]]
 name = "docutils"
 version = "0.22.4"
 source = { registry = "https://pypi.org/simple" }
@@ -1566,6 +1630,49 @@ wheels = [
 ]
 
 [[package]]
+name = "h5py"
+version = "3.16.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/db/33/acd0ce6863b6c0d7735007df01815403f5589a21ff8c2e1ee2587a38f548/h5py-3.16.0.tar.gz", hash = "sha256:a0dbaad796840ccaa67a4c144a0d0c8080073c34c76d5a6941d6818678ef2738", size = 446526, upload-time = "2026-03-06T13:49:08.07Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c8/c0/5d4119dba94093bbafede500d3defd2f5eab7897732998c04b54021e530b/h5py-3.16.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:c5313566f4643121a78503a473f0fb1e6dcc541d5115c44f05e037609c565c4d", size = 3685604, upload-time = "2026-03-06T13:48:04.198Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/42/c84efcc1d4caebafb1ecd8be4643f39c85c47a80fe254d92b8b43b1eadaf/h5py-3.16.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:42b012933a83e1a558c673176676a10ce2fd3759976a0fedee1e672d1e04fc9d", size = 3061940, upload-time = "2026-03-06T13:48:05.783Z" },
+    { url = "https://files.pythonhosted.org/packages/89/84/06281c82d4d1686fde1ac6b0f307c50918f1c0151062445ab3b6fa5a921d/h5py-3.16.0-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:ff24039e2573297787c3063df64b60aab0591980ac898329a08b0320e0cf2527", size = 5198852, upload-time = "2026-03-06T13:48:07.482Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/e9/1a19e42cd43cc1365e127db6aae85e1c671da1d9a5d746f4d34a50edb577/h5py-3.16.0-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:dfc21898ff025f1e8e67e194965a95a8d4754f452f83454538f98f8a3fcb207e", size = 5405250, upload-time = "2026-03-06T13:48:09.628Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/8e/9790c1655eabeb85b92b1ecab7d7e62a2069e53baefd58c98f0909c7a948/h5py-3.16.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:698dd69291272642ffda44a0ecd6cd3bda5faf9621452d255f57ce91487b9794", size = 5190108, upload-time = "2026-03-06T13:48:11.26Z" },
+    { url = "https://files.pythonhosted.org/packages/51/d7/ab693274f1bd7e8c5f9fdd6c7003a88d59bedeaf8752716a55f532924fbb/h5py-3.16.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:2b2c02b0a160faed5fb33f1ba8a264a37ee240b22e049ecc827345d0d9043074", size = 5419216, upload-time = "2026-03-06T13:48:13.322Z" },
+    { url = "https://files.pythonhosted.org/packages/03/c1/0976b235cf29ead553e22f2fb6385a8252b533715e00d0ae52ed7b900582/h5py-3.16.0-cp312-cp312-win_amd64.whl", hash = "sha256:96b422019a1c8975c2d5dadcf61d4ba6f01c31f92bbde6e4649607885fe502d6", size = 3182868, upload-time = "2026-03-06T13:48:15.759Z" },
+    { url = "https://files.pythonhosted.org/packages/14/d9/866b7e570b39070f92d47b0ff1800f0f8239b6f9e45f02363d7112336c1f/h5py-3.16.0-cp312-cp312-win_arm64.whl", hash = "sha256:39c2838fb1e8d97bcf1755e60ad1f3dd76a7b2a475928dc321672752678b96db", size = 2653286, upload-time = "2026-03-06T13:48:17.279Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/9e/6142ebfda0cb6e9349c091eae73c2e01a770b7659255248d637bec54a88b/h5py-3.16.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:370a845f432c2c9619db8eed334d1e610c6015796122b0e57aa46312c22617d9", size = 3671808, upload-time = "2026-03-06T13:48:19.737Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/65/5e088a45d0f43cd814bc5bec521c051d42005a472e804b1a36c48dada09b/h5py-3.16.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:42108e93326c50c2810025aade9eac9d6827524cdccc7d4b75a546e5ab308edb", size = 3045837, upload-time = "2026-03-06T13:48:21.854Z" },
+    { url = "https://files.pythonhosted.org/packages/da/1e/6172269e18cc5a484e2913ced33339aad588e02ba407fafd00d369e22ef3/h5py-3.16.0-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:099f2525c9dcf28de366970a5fb34879aab20491589fa89ce2863a84218bb524", size = 5193860, upload-time = "2026-03-06T13:48:24.071Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/98/ef2b6fe2903e377cbe870c3b2800d62552f1e3dbe81ce49e1923c53d1c5c/h5py-3.16.0-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:9300ad32dea9dfc5171f94d5f6948e159ed93e4701280b0f508773b3f582f402", size = 5400417, upload-time = "2026-03-06T13:48:25.728Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/81/5b62d760039eed64348c98129d17061fdfc7839fc9c04eaaad6dee1004e4/h5py-3.16.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:171038f23bccddfc23f344cadabdfc9917ff554db6a0d417180d2747fe4c75a7", size = 5185214, upload-time = "2026-03-06T13:48:27.436Z" },
+    { url = "https://files.pythonhosted.org/packages/28/c4/532123bcd9080e250696779c927f2cb906c8bf3447df98f5ceb8dcded539/h5py-3.16.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:7e420b539fb6023a259a1b14d4c9f6df8cf50d7268f48e161169987a57b737ff", size = 5414598, upload-time = "2026-03-06T13:48:29.49Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/d9/a27997f84341fc0dfcdd1fe4179b6ba6c32a7aa880fdb8c514d4dad6fba3/h5py-3.16.0-cp313-cp313-win_amd64.whl", hash = "sha256:18f2bbcd545e6991412253b98727374c356d67caa920e68dc79eab36bf5fedad", size = 3175509, upload-time = "2026-03-06T13:48:31.131Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/23/bb8647521d4fd770c30a76cfc6cb6a2f5495868904054e92f2394c5a78ff/h5py-3.16.0-cp313-cp313-win_arm64.whl", hash = "sha256:656f00e4d903199a1d58df06b711cf3ca632b874b4207b7dbec86185b5c8c7d4", size = 2647362, upload-time = "2026-03-06T13:48:33.411Z" },
+    { url = "https://files.pythonhosted.org/packages/48/3c/7fcd9b4c9eed82e91fb15568992561019ae7a829d1f696b2c844355d95dd/h5py-3.16.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:9c9d307c0ef862d1cd5714f72ecfafe0a5d7529c44845afa8de9f46e5ba8bd65", size = 3678608, upload-time = "2026-03-06T13:48:35.183Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/b7/9366ed44ced9b7ef357ab48c94205280276db9d7f064aa3012a97227e966/h5py-3.16.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:8c1eff849cdd53cbc73c214c30ebdb6f1bb8b64790b4b4fc36acdb5e43570210", size = 3054773, upload-time = "2026-03-06T13:48:37.139Z" },
+    { url = "https://files.pythonhosted.org/packages/58/a5/4964bc0e91e86340c2bbda83420225b2f770dcf1eb8a39464871ad769436/h5py-3.16.0-cp314-cp314-manylinux_2_28_aarch64.whl", hash = "sha256:e2c04d129f180019e216ee5f9c40b78a418634091c8782e1f723a6ca3658b965", size = 5198886, upload-time = "2026-03-06T13:48:38.879Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/16/d905e7f53e661ce2c24686c38048d8e2b750ffc4350009d41c4e6c6c9826/h5py-3.16.0-cp314-cp314-manylinux_2_28_x86_64.whl", hash = "sha256:e4360f15875a532bc7b98196c7592ed4fc92672a57c0a621355961cafb17a6dd", size = 5404883, upload-time = "2026-03-06T13:48:41.324Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/f2/58f34cb74af46d39f4cd18ea20909a8514960c5a3e5b92fd06a28161e0a8/h5py-3.16.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:3fae9197390c325e62e0a1aa977f2f62d994aa87aab182abbea85479b791197c", size = 5192039, upload-time = "2026-03-06T13:48:43.117Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/ca/934a39c24ce2e2db017268c08da0537c20fa0be7e1549be3e977313fc8f5/h5py-3.16.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:43259303989ac8adacc9986695b31e35dba6fd1e297ff9c6a04b7da5542139cc", size = 5421526, upload-time = "2026-03-06T13:48:44.838Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/14/615a450205e1b56d16c6783f5ccd116cde05550faad70ae077c955654a75/h5py-3.16.0-cp314-cp314-win_amd64.whl", hash = "sha256:fa48993a0b799737ba7fd21e2350fa0a60701e58180fae9f2de834bc39a147ab", size = 3183263, upload-time = "2026-03-06T13:48:47.117Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/48/a6faef5ed632cae0c65ac6b214a6614a0b510c3183532c521bdb0055e117/h5py-3.16.0-cp314-cp314-win_arm64.whl", hash = "sha256:1897a771a7f40d05c262fc8f37376ec37873218544b70216872876c627640f63", size = 2663450, upload-time = "2026-03-06T13:48:48.707Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/32/0c8bb8aedb62c772cf7c1d427c7d1951477e8c2835f872bc0a13d1f85f86/h5py-3.16.0-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:15922e485844f77c0b9d275396d435db3baa58292a9c2176a386e072e0cf2491", size = 3760693, upload-time = "2026-03-06T13:48:50.453Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/1f/fcc5977d32d6387c5c9a694afee716a5e20658ac08b3ff24fdec79fb05f2/h5py-3.16.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:df02dd29bd247f98674634dfe41f89fd7c16ba3d7de8695ec958f58404a4e618", size = 3181305, upload-time = "2026-03-06T13:48:52.221Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/a1/af87f64b9f986889884243643621ebbd4ac72472ba8ec8cec891ac8e2ca1/h5py-3.16.0-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:0f456f556e4e2cebeebd9d66adf8dc321770a42593494a0b6f0af54a7567b242", size = 5074061, upload-time = "2026-03-06T13:48:54.089Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/d0/146f5eaff3dc246a9c7f6e5e4f42bd45cc613bce16693bcd4d1f7c958bf5/h5py-3.16.0-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:3e6cb3387c756de6a9492d601553dffea3fe11b5f22b443aac708c69f3f55e16", size = 5279216, upload-time = "2026-03-06T13:48:56.75Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/9d/12a13424f1e604fc7df9497b73c0356fb78c2fb206abd7465ce47226e8fd/h5py-3.16.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:8389e13a1fd745ad2856873e8187fd10268b2d9677877bb667b41aebd771d8b7", size = 5070068, upload-time = "2026-03-06T13:48:59.169Z" },
+    { url = "https://files.pythonhosted.org/packages/41/8c/bbe98f813722b4873818a8db3e15aa3e625b59278566905ac439725e8070/h5py-3.16.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:346df559a0f7dcb31cf8e44805319e2ab24b8957c45e7708ce503b2ec79ba725", size = 5300253, upload-time = "2026-03-06T13:49:02.033Z" },
+    { url = "https://files.pythonhosted.org/packages/32/9e/87e6705b4d6890e7cecdf876e2a7d3e40654a2ae37482d79a6f1b87f7b92/h5py-3.16.0-cp314-cp314t-win_amd64.whl", hash = "sha256:4c6ab014ab704b4feaa719ae783b86522ed0bf1f82184704ed3c9e4e3228796e", size = 3381671, upload-time = "2026-03-06T13:49:04.351Z" },
+    { url = "https://files.pythonhosted.org/packages/96/91/9fad90cfc5f9b2489c7c26ad897157bce82f0e9534a986a221b99760b23b/h5py-3.16.0-cp314-cp314t-win_arm64.whl", hash = "sha256:faca8fb4e4319c09d83337adc80b2ca7d5c5a343c2d6f1b6388f32cfecca13c1", size = 2740706, upload-time = "2026-03-06T13:49:06.347Z" },
+]
+
+[[package]]
 name = "hf-xet"
 version = "1.4.3"
 source = { registry = "https://pypi.org/simple" }
@@ -1797,6 +1904,18 @@ wheels = [
 ]
 
 [[package]]
+name = "jinja2"
+version = "3.1.6"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markupsafe" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/df/bf/f7da0350254c0ed7c72f3e33cef02e048281fec7ecec5f032d4aac52226b/jinja2-3.1.6.tar.gz", hash = "sha256:0137fb05990d35f1275a587e9aee6d56da821fc83491a0fb838183be43f66d6d", size = 245115, upload-time = "2025-03-05T20:05:02.478Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/62/a1/3d680cbfd5f4b8f15abc1d571870c5fc3e594bb582bc3b64ea099db13e56/jinja2-3.1.6-py3-none-any.whl", hash = "sha256:85ece4451f492d0c13c5dd7c13a64681a86afae63a5f347908daf103ce6d2f67", size = 134899, upload-time = "2025-03-05T20:05:00.369Z" },
+]
+
+[[package]]
 name = "jiter"
 version = "0.14.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1946,6 +2065,15 @@ sdist = { url = "https://files.pythonhosted.org/packages/43/4b/674af6ef2f97d56f0
 wheels = [
     { url = "https://files.pythonhosted.org/packages/81/db/e655086b7f3a705df045bf0933bdd9c2f79bb3c97bfef1384598bb79a217/keyring-25.7.0-py3-none-any.whl", hash = "sha256:be4a0b195f149690c166e850609a477c532ddbfbaed96a404d4e43f8d5e2689f", size = 39160, upload-time = "2025-11-16T16:26:08.402Z" },
 ]
+
+[[package]]
+name = "langdetect"
+version = "1.0.9"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "six" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/0e/72/a3add0e4eec4eb9e2569554f7c70f4a3c27712f40e3284d483e88094cc0e/langdetect-1.0.9.tar.gz", hash = "sha256:cbc1fef89f8d062739774bd51eda3da3274006b3661d199c2655f6b3f6d605a0", size = 981474, upload-time = "2021-05-07T07:54:13.562Z" }
 
 [[package]]
 name = "librt"
@@ -2132,6 +2260,69 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/5b/f5/4ec618ed16cc4f8fb3b701563655a69816155e79e24a17b651541804721d/markdown_it_py-4.0.0.tar.gz", hash = "sha256:cb0a2b4aa34f932c007117b194e945bd74e0ec24133ceb5bac59009cda1cb9f3", size = 73070, upload-time = "2025-08-11T12:57:52.854Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/94/54/e7d793b573f298e1c9013b8c4dade17d481164aa517d1d7148619c2cedbf/markdown_it_py-4.0.0-py3-none-any.whl", hash = "sha256:87327c59b172c5011896038353a81343b6754500a08cd7a4973bb48c6d578147", size = 87321, upload-time = "2025-08-11T12:57:51.923Z" },
+]
+
+[[package]]
+name = "markupsafe"
+version = "3.0.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7e/99/7690b6d4034fffd95959cbe0c02de8deb3098cc577c67bb6a24fe5d7caa7/markupsafe-3.0.3.tar.gz", hash = "sha256:722695808f4b6457b320fdc131280796bdceb04ab50fe1795cd540799ebe1698", size = 80313, upload-time = "2025-09-27T18:37:40.426Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5a/72/147da192e38635ada20e0a2e1a51cf8823d2119ce8883f7053879c2199b5/markupsafe-3.0.3-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:d53197da72cc091b024dd97249dfc7794d6a56530370992a5e1a08983ad9230e", size = 11615, upload-time = "2025-09-27T18:36:30.854Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/81/7e4e08678a1f98521201c3079f77db69fb552acd56067661f8c2f534a718/markupsafe-3.0.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:1872df69a4de6aead3491198eaf13810b565bdbeec3ae2dc8780f14458ec73ce", size = 12020, upload-time = "2025-09-27T18:36:31.971Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/2c/799f4742efc39633a1b54a92eec4082e4f815314869865d876824c257c1e/markupsafe-3.0.3-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3a7e8ae81ae39e62a41ec302f972ba6ae23a5c5396c8e60113e9066ef893da0d", size = 24332, upload-time = "2025-09-27T18:36:32.813Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/2e/8d0c2ab90a8c1d9a24f0399058ab8519a3279d1bd4289511d74e909f060e/markupsafe-3.0.3-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d6dd0be5b5b189d31db7cda48b91d7e0a9795f31430b7f271219ab30f1d3ac9d", size = 22947, upload-time = "2025-09-27T18:36:33.86Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/54/887f3092a85238093a0b2154bd629c89444f395618842e8b0c41783898ea/markupsafe-3.0.3-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:94c6f0bb423f739146aec64595853541634bde58b2135f27f61c1ffd1cd4d16a", size = 21962, upload-time = "2025-09-27T18:36:35.099Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/2f/336b8c7b6f4a4d95e91119dc8521402461b74a485558d8f238a68312f11c/markupsafe-3.0.3-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:be8813b57049a7dc738189df53d69395eba14fb99345e0a5994914a3864c8a4b", size = 23760, upload-time = "2025-09-27T18:36:36.001Z" },
+    { url = "https://files.pythonhosted.org/packages/32/43/67935f2b7e4982ffb50a4d169b724d74b62a3964bc1a9a527f5ac4f1ee2b/markupsafe-3.0.3-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:83891d0e9fb81a825d9a6d61e3f07550ca70a076484292a70fde82c4b807286f", size = 21529, upload-time = "2025-09-27T18:36:36.906Z" },
+    { url = "https://files.pythonhosted.org/packages/89/e0/4486f11e51bbba8b0c041098859e869e304d1c261e59244baa3d295d47b7/markupsafe-3.0.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:77f0643abe7495da77fb436f50f8dab76dbc6e5fd25d39589a0f1fe6548bfa2b", size = 23015, upload-time = "2025-09-27T18:36:37.868Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/e1/78ee7a023dac597a5825441ebd17170785a9dab23de95d2c7508ade94e0e/markupsafe-3.0.3-cp312-cp312-win32.whl", hash = "sha256:d88b440e37a16e651bda4c7c2b930eb586fd15ca7406cb39e211fcff3bf3017d", size = 14540, upload-time = "2025-09-27T18:36:38.761Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/5b/bec5aa9bbbb2c946ca2733ef9c4ca91c91b6a24580193e891b5f7dbe8e1e/markupsafe-3.0.3-cp312-cp312-win_amd64.whl", hash = "sha256:26a5784ded40c9e318cfc2bdb30fe164bdb8665ded9cd64d500a34fb42067b1c", size = 15105, upload-time = "2025-09-27T18:36:39.701Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/f1/216fc1bbfd74011693a4fd837e7026152e89c4bcf3e77b6692fba9923123/markupsafe-3.0.3-cp312-cp312-win_arm64.whl", hash = "sha256:35add3b638a5d900e807944a078b51922212fb3dedb01633a8defc4b01a3c85f", size = 13906, upload-time = "2025-09-27T18:36:40.689Z" },
+    { url = "https://files.pythonhosted.org/packages/38/2f/907b9c7bbba283e68f20259574b13d005c121a0fa4c175f9bed27c4597ff/markupsafe-3.0.3-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:e1cf1972137e83c5d4c136c43ced9ac51d0e124706ee1c8aa8532c1287fa8795", size = 11622, upload-time = "2025-09-27T18:36:41.777Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/d9/5f7756922cdd676869eca1c4e3c0cd0df60ed30199ffd775e319089cb3ed/markupsafe-3.0.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:116bb52f642a37c115f517494ea5feb03889e04df47eeff5b130b1808ce7c219", size = 12029, upload-time = "2025-09-27T18:36:43.257Z" },
+    { url = "https://files.pythonhosted.org/packages/00/07/575a68c754943058c78f30db02ee03a64b3c638586fba6a6dd56830b30a3/markupsafe-3.0.3-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:133a43e73a802c5562be9bbcd03d090aa5a1fe899db609c29e8c8d815c5f6de6", size = 24374, upload-time = "2025-09-27T18:36:44.508Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/21/9b05698b46f218fc0e118e1f8168395c65c8a2c750ae2bab54fc4bd4e0e8/markupsafe-3.0.3-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ccfcd093f13f0f0b7fdd0f198b90053bf7b2f02a3927a30e63f3ccc9df56b676", size = 22980, upload-time = "2025-09-27T18:36:45.385Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/71/544260864f893f18b6827315b988c146b559391e6e7e8f7252839b1b846a/markupsafe-3.0.3-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:509fa21c6deb7a7a273d629cf5ec029bc209d1a51178615ddf718f5918992ab9", size = 21990, upload-time = "2025-09-27T18:36:46.916Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/28/b50fc2f74d1ad761af2f5dcce7492648b983d00a65b8c0e0cb457c82ebbe/markupsafe-3.0.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:a4afe79fb3de0b7097d81da19090f4df4f8d3a2b3adaa8764138aac2e44f3af1", size = 23784, upload-time = "2025-09-27T18:36:47.884Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/76/104b2aa106a208da8b17a2fb72e033a5a9d7073c68f7e508b94916ed47a9/markupsafe-3.0.3-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:795e7751525cae078558e679d646ae45574b47ed6e7771863fcc079a6171a0fc", size = 21588, upload-time = "2025-09-27T18:36:48.82Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/99/16a5eb2d140087ebd97180d95249b00a03aa87e29cc224056274f2e45fd6/markupsafe-3.0.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:8485f406a96febb5140bfeca44a73e3ce5116b2501ac54fe953e488fb1d03b12", size = 23041, upload-time = "2025-09-27T18:36:49.797Z" },
+    { url = "https://files.pythonhosted.org/packages/19/bc/e7140ed90c5d61d77cea142eed9f9c303f4c4806f60a1044c13e3f1471d0/markupsafe-3.0.3-cp313-cp313-win32.whl", hash = "sha256:bdd37121970bfd8be76c5fb069c7751683bdf373db1ed6c010162b2a130248ed", size = 14543, upload-time = "2025-09-27T18:36:51.584Z" },
+    { url = "https://files.pythonhosted.org/packages/05/73/c4abe620b841b6b791f2edc248f556900667a5a1cf023a6646967ae98335/markupsafe-3.0.3-cp313-cp313-win_amd64.whl", hash = "sha256:9a1abfdc021a164803f4d485104931fb8f8c1efd55bc6b748d2f5774e78b62c5", size = 15113, upload-time = "2025-09-27T18:36:52.537Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/3a/fa34a0f7cfef23cf9500d68cb7c32dd64ffd58a12b09225fb03dd37d5b80/markupsafe-3.0.3-cp313-cp313-win_arm64.whl", hash = "sha256:7e68f88e5b8799aa49c85cd116c932a1ac15caaa3f5db09087854d218359e485", size = 13911, upload-time = "2025-09-27T18:36:53.513Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/d7/e05cd7efe43a88a17a37b3ae96e79a19e846f3f456fe79c57ca61356ef01/markupsafe-3.0.3-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:218551f6df4868a8d527e3062d0fb968682fe92054e89978594c28e642c43a73", size = 11658, upload-time = "2025-09-27T18:36:54.819Z" },
+    { url = "https://files.pythonhosted.org/packages/99/9e/e412117548182ce2148bdeacdda3bb494260c0b0184360fe0d56389b523b/markupsafe-3.0.3-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:3524b778fe5cfb3452a09d31e7b5adefeea8c5be1d43c4f810ba09f2ceb29d37", size = 12066, upload-time = "2025-09-27T18:36:55.714Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/e6/fa0ffcda717ef64a5108eaa7b4f5ed28d56122c9a6d70ab8b72f9f715c80/markupsafe-3.0.3-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:4e885a3d1efa2eadc93c894a21770e4bc67899e3543680313b09f139e149ab19", size = 25639, upload-time = "2025-09-27T18:36:56.908Z" },
+    { url = "https://files.pythonhosted.org/packages/96/ec/2102e881fe9d25fc16cb4b25d5f5cde50970967ffa5dddafdb771237062d/markupsafe-3.0.3-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8709b08f4a89aa7586de0aadc8da56180242ee0ada3999749b183aa23df95025", size = 23569, upload-time = "2025-09-27T18:36:57.913Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/30/6f2fce1f1f205fc9323255b216ca8a235b15860c34b6798f810f05828e32/markupsafe-3.0.3-cp313-cp313t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:b8512a91625c9b3da6f127803b166b629725e68af71f8184ae7e7d54686a56d6", size = 23284, upload-time = "2025-09-27T18:36:58.833Z" },
+    { url = "https://files.pythonhosted.org/packages/58/47/4a0ccea4ab9f5dcb6f79c0236d954acb382202721e704223a8aafa38b5c8/markupsafe-3.0.3-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:9b79b7a16f7fedff2495d684f2b59b0457c3b493778c9eed31111be64d58279f", size = 24801, upload-time = "2025-09-27T18:36:59.739Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/70/3780e9b72180b6fecb83a4814d84c3bf4b4ae4bf0b19c27196104149734c/markupsafe-3.0.3-cp313-cp313t-musllinux_1_2_riscv64.whl", hash = "sha256:12c63dfb4a98206f045aa9563db46507995f7ef6d83b2f68eda65c307c6829eb", size = 22769, upload-time = "2025-09-27T18:37:00.719Z" },
+    { url = "https://files.pythonhosted.org/packages/98/c5/c03c7f4125180fc215220c035beac6b9cb684bc7a067c84fc69414d315f5/markupsafe-3.0.3-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:8f71bc33915be5186016f675cd83a1e08523649b0e33efdb898db577ef5bb009", size = 23642, upload-time = "2025-09-27T18:37:01.673Z" },
+    { url = "https://files.pythonhosted.org/packages/80/d6/2d1b89f6ca4bff1036499b1e29a1d02d282259f3681540e16563f27ebc23/markupsafe-3.0.3-cp313-cp313t-win32.whl", hash = "sha256:69c0b73548bc525c8cb9a251cddf1931d1db4d2258e9599c28c07ef3580ef354", size = 14612, upload-time = "2025-09-27T18:37:02.639Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/98/e48a4bfba0a0ffcf9925fe2d69240bfaa19c6f7507b8cd09c70684a53c1e/markupsafe-3.0.3-cp313-cp313t-win_amd64.whl", hash = "sha256:1b4b79e8ebf6b55351f0d91fe80f893b4743f104bff22e90697db1590e47a218", size = 15200, upload-time = "2025-09-27T18:37:03.582Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/72/e3cc540f351f316e9ed0f092757459afbc595824ca724cbc5a5d4263713f/markupsafe-3.0.3-cp313-cp313t-win_arm64.whl", hash = "sha256:ad2cf8aa28b8c020ab2fc8287b0f823d0a7d8630784c31e9ee5edea20f406287", size = 13973, upload-time = "2025-09-27T18:37:04.929Z" },
+    { url = "https://files.pythonhosted.org/packages/33/8a/8e42d4838cd89b7dde187011e97fe6c3af66d8c044997d2183fbd6d31352/markupsafe-3.0.3-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:eaa9599de571d72e2daf60164784109f19978b327a3910d3e9de8c97b5b70cfe", size = 11619, upload-time = "2025-09-27T18:37:06.342Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/64/7660f8a4a8e53c924d0fa05dc3a55c9cee10bbd82b11c5afb27d44b096ce/markupsafe-3.0.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:c47a551199eb8eb2121d4f0f15ae0f923d31350ab9280078d1e5f12b249e0026", size = 12029, upload-time = "2025-09-27T18:37:07.213Z" },
+    { url = "https://files.pythonhosted.org/packages/da/ef/e648bfd021127bef5fa12e1720ffed0c6cbb8310c8d9bea7266337ff06de/markupsafe-3.0.3-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f34c41761022dd093b4b6896d4810782ffbabe30f2d443ff5f083e0cbbb8c737", size = 24408, upload-time = "2025-09-27T18:37:09.572Z" },
+    { url = "https://files.pythonhosted.org/packages/41/3c/a36c2450754618e62008bf7435ccb0f88053e07592e6028a34776213d877/markupsafe-3.0.3-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:457a69a9577064c05a97c41f4e65148652db078a3a509039e64d3467b9e7ef97", size = 23005, upload-time = "2025-09-27T18:37:10.58Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/20/b7fdf89a8456b099837cd1dc21974632a02a999ec9bf7ca3e490aacd98e7/markupsafe-3.0.3-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:e8afc3f2ccfa24215f8cb28dcf43f0113ac3c37c2f0f0806d8c70e4228c5cf4d", size = 22048, upload-time = "2025-09-27T18:37:11.547Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/a7/591f592afdc734f47db08a75793a55d7fbcc6902a723ae4cfbab61010cc5/markupsafe-3.0.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:ec15a59cf5af7be74194f7ab02d0f59a62bdcf1a537677ce67a2537c9b87fcda", size = 23821, upload-time = "2025-09-27T18:37:12.48Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/33/45b24e4f44195b26521bc6f1a82197118f74df348556594bd2262bda1038/markupsafe-3.0.3-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:0eb9ff8191e8498cca014656ae6b8d61f39da5f95b488805da4bb029cccbfbaf", size = 21606, upload-time = "2025-09-27T18:37:13.485Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/0e/53dfaca23a69fbfbbf17a4b64072090e70717344c52eaaaa9c5ddff1e5f0/markupsafe-3.0.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:2713baf880df847f2bece4230d4d094280f4e67b1e813eec43b4c0e144a34ffe", size = 23043, upload-time = "2025-09-27T18:37:14.408Z" },
+    { url = "https://files.pythonhosted.org/packages/46/11/f333a06fc16236d5238bfe74daccbca41459dcd8d1fa952e8fbd5dccfb70/markupsafe-3.0.3-cp314-cp314-win32.whl", hash = "sha256:729586769a26dbceff69f7a7dbbf59ab6572b99d94576a5592625d5b411576b9", size = 14747, upload-time = "2025-09-27T18:37:15.36Z" },
+    { url = "https://files.pythonhosted.org/packages/28/52/182836104b33b444e400b14f797212f720cbc9ed6ba34c800639d154e821/markupsafe-3.0.3-cp314-cp314-win_amd64.whl", hash = "sha256:bdc919ead48f234740ad807933cdf545180bfbe9342c2bb451556db2ed958581", size = 15341, upload-time = "2025-09-27T18:37:16.496Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/18/acf23e91bd94fd7b3031558b1f013adfa21a8e407a3fdb32745538730382/markupsafe-3.0.3-cp314-cp314-win_arm64.whl", hash = "sha256:5a7d5dc5140555cf21a6fefbdbf8723f06fcd2f63ef108f2854de715e4422cb4", size = 14073, upload-time = "2025-09-27T18:37:17.476Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/f0/57689aa4076e1b43b15fdfa646b04653969d50cf30c32a102762be2485da/markupsafe-3.0.3-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:1353ef0c1b138e1907ae78e2f6c63ff67501122006b0f9abad68fda5f4ffc6ab", size = 11661, upload-time = "2025-09-27T18:37:18.453Z" },
+    { url = "https://files.pythonhosted.org/packages/89/c3/2e67a7ca217c6912985ec766c6393b636fb0c2344443ff9d91404dc4c79f/markupsafe-3.0.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:1085e7fbddd3be5f89cc898938f42c0b3c711fdcb37d75221de2666af647c175", size = 12069, upload-time = "2025-09-27T18:37:19.332Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/00/be561dce4e6ca66b15276e184ce4b8aec61fe83662cce2f7d72bd3249d28/markupsafe-3.0.3-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1b52b4fb9df4eb9ae465f8d0c228a00624de2334f216f178a995ccdcf82c4634", size = 25670, upload-time = "2025-09-27T18:37:20.245Z" },
+    { url = "https://files.pythonhosted.org/packages/50/09/c419f6f5a92e5fadde27efd190eca90f05e1261b10dbd8cbcb39cd8ea1dc/markupsafe-3.0.3-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:fed51ac40f757d41b7c48425901843666a6677e3e8eb0abcff09e4ba6e664f50", size = 23598, upload-time = "2025-09-27T18:37:21.177Z" },
+    { url = "https://files.pythonhosted.org/packages/22/44/a0681611106e0b2921b3033fc19bc53323e0b50bc70cffdd19f7d679bb66/markupsafe-3.0.3-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:f190daf01f13c72eac4efd5c430a8de82489d9cff23c364c3ea822545032993e", size = 23261, upload-time = "2025-09-27T18:37:22.167Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/57/1b0b3f100259dc9fffe780cfb60d4be71375510e435efec3d116b6436d43/markupsafe-3.0.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:e56b7d45a839a697b5eb268c82a71bd8c7f6c94d6fd50c3d577fa39a9f1409f5", size = 24835, upload-time = "2025-09-27T18:37:23.296Z" },
+    { url = "https://files.pythonhosted.org/packages/26/6a/4bf6d0c97c4920f1597cc14dd720705eca0bf7c787aebc6bb4d1bead5388/markupsafe-3.0.3-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:f3e98bb3798ead92273dc0e5fd0f31ade220f59a266ffd8a4f6065e0a3ce0523", size = 22733, upload-time = "2025-09-27T18:37:24.237Z" },
+    { url = "https://files.pythonhosted.org/packages/14/c7/ca723101509b518797fedc2fdf79ba57f886b4aca8a7d31857ba3ee8281f/markupsafe-3.0.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:5678211cb9333a6468fb8d8be0305520aa073f50d17f089b5b4b477ea6e67fdc", size = 23672, upload-time = "2025-09-27T18:37:25.271Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/df/5bd7a48c256faecd1d36edc13133e51397e41b73bb77e1a69deab746ebac/markupsafe-3.0.3-cp314-cp314t-win32.whl", hash = "sha256:915c04ba3851909ce68ccc2b8e2cd691618c4dc4c4232fb7982bca3f41fd8c3d", size = 14819, upload-time = "2025-09-27T18:37:26.285Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/8a/0402ba61a2f16038b48b39bccca271134be00c5c9f0f623208399333c448/markupsafe-3.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4faffd047e07c38848ce017e8725090413cd80cbc23d86e55c587bf979e579c9", size = 15426, upload-time = "2025-09-27T18:37:27.316Z" },
+    { url = "https://files.pythonhosted.org/packages/70/bc/6f1c2f612465f5fa89b95bead1f44dcb607670fd42891d8fdcd5d039f4f4/markupsafe-3.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:32001d6a8fc98c8cb5c947787c5d08b0a50663d139f1305bac5885d98d9b40fa", size = 14146, upload-time = "2025-09-27T18:37:28.327Z" },
 ]
 
 [[package]]
@@ -2339,6 +2530,42 @@ wheels = [
 ]
 
 [[package]]
+name = "ml-dtypes"
+version = "0.5.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/0e/4a/c27b42ed9b1c7d13d9ba8b6905dece787d6259152f2309338aed29b2447b/ml_dtypes-0.5.4.tar.gz", hash = "sha256:8ab06a50fb9bf9666dd0fe5dfb4676fa2b0ac0f31ecff72a6c3af8e22c063453", size = 692314, upload-time = "2025-11-17T22:32:31.031Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a8/b8/3c70881695e056f8a32f8b941126cf78775d9a4d7feba8abcb52cb7b04f2/ml_dtypes-0.5.4-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:a174837a64f5b16cab6f368171a1a03a27936b31699d167684073ff1c4237dac", size = 676927, upload-time = "2025-11-17T22:31:48.182Z" },
+    { url = "https://files.pythonhosted.org/packages/54/0f/428ef6881782e5ebb7eca459689448c0394fa0a80bea3aa9262cba5445ea/ml_dtypes-0.5.4-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a7f7c643e8b1320fd958bf098aa7ecf70623a42ec5154e3be3be673f4c34d900", size = 5028464, upload-time = "2025-11-17T22:31:50.135Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/cb/28ce52eb94390dda42599c98ea0204d74799e4d8047a0eb559b6fd648056/ml_dtypes-0.5.4-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9ad459e99793fa6e13bd5b7e6792c8f9190b4e5a1b45c63aba14a4d0a7f1d5ff", size = 5009002, upload-time = "2025-11-17T22:31:52.001Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/f0/0cfadd537c5470378b1b32bd859cf2824972174b51b873c9d95cfd7475a5/ml_dtypes-0.5.4-cp312-cp312-win_amd64.whl", hash = "sha256:c1a953995cccb9e25a4ae19e34316671e4e2edaebe4cf538229b1fc7109087b7", size = 212222, upload-time = "2025-11-17T22:31:53.742Z" },
+    { url = "https://files.pythonhosted.org/packages/16/2e/9acc86985bfad8f2c2d30291b27cd2bb4c74cea08695bd540906ed744249/ml_dtypes-0.5.4-cp312-cp312-win_arm64.whl", hash = "sha256:9bad06436568442575beb2d03389aa7456c690a5b05892c471215bfd8cf39460", size = 160793, upload-time = "2025-11-17T22:31:55.358Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/a1/4008f14bbc616cfb1ac5b39ea485f9c63031c4634ab3f4cf72e7541f816a/ml_dtypes-0.5.4-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:8c760d85a2f82e2bed75867079188c9d18dae2ee77c25a54d60e9cc79be1bc48", size = 676888, upload-time = "2025-11-17T22:31:56.907Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/b7/dff378afc2b0d5a7d6cd9d3209b60474d9819d1189d347521e1688a60a53/ml_dtypes-0.5.4-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ce756d3a10d0c4067172804c9cc276ba9cc0ff47af9078ad439b075d1abdc29b", size = 5036993, upload-time = "2025-11-17T22:31:58.497Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/33/40cd74219417e78b97c47802037cf2d87b91973e18bb968a7da48a96ea44/ml_dtypes-0.5.4-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:533ce891ba774eabf607172254f2e7260ba5f57bdd64030c9a4fcfbd99815d0d", size = 5010956, upload-time = "2025-11-17T22:31:59.931Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/8b/200088c6859d8221454825959df35b5244fa9bdf263fd0249ac5fb75e281/ml_dtypes-0.5.4-cp313-cp313-win_amd64.whl", hash = "sha256:f21c9219ef48ca5ee78402d5cc831bd58ea27ce89beda894428bc67a52da5328", size = 212224, upload-time = "2025-11-17T22:32:01.349Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/75/dfc3775cb36367816e678f69a7843f6f03bd4e2bcd79941e01ea960a068e/ml_dtypes-0.5.4-cp313-cp313-win_arm64.whl", hash = "sha256:35f29491a3e478407f7047b8a4834e4640a77d2737e0b294d049746507af5175", size = 160798, upload-time = "2025-11-17T22:32:02.864Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/74/e9ddb35fd1dd43b1106c20ced3f53c2e8e7fc7598c15638e9f80677f81d4/ml_dtypes-0.5.4-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:304ad47faa395415b9ccbcc06a0350800bc50eda70f0e45326796e27c62f18b6", size = 702083, upload-time = "2025-11-17T22:32:04.08Z" },
+    { url = "https://files.pythonhosted.org/packages/74/f5/667060b0aed1aa63166b22897fdf16dca9eb704e6b4bbf86848d5a181aa7/ml_dtypes-0.5.4-cp313-cp313t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6a0df4223b514d799b8a1629c65ddc351b3efa833ccf7f8ea0cf654a61d1e35d", size = 5354111, upload-time = "2025-11-17T22:32:05.546Z" },
+    { url = "https://files.pythonhosted.org/packages/40/49/0f8c498a28c0efa5f5c95a9e374c83ec1385ca41d0e85e7cf40e5d519a21/ml_dtypes-0.5.4-cp313-cp313t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:531eff30e4d368cb6255bc2328d070e35836aa4f282a0fb5f3a0cd7260257298", size = 5366453, upload-time = "2025-11-17T22:32:07.115Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/27/12607423d0a9c6bbbcc780ad19f1f6baa2b68b18ce4bddcdc122c4c68dc9/ml_dtypes-0.5.4-cp313-cp313t-win_amd64.whl", hash = "sha256:cb73dccfc991691c444acc8c0012bee8f2470da826a92e3a20bb333b1a7894e6", size = 225612, upload-time = "2025-11-17T22:32:08.615Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/80/5a5929e92c72936d5b19872c5fb8fc09327c1da67b3b68c6a13139e77e20/ml_dtypes-0.5.4-cp313-cp313t-win_arm64.whl", hash = "sha256:3bbbe120b915090d9dd1375e4684dd17a20a2491ef25d640a908281da85e73f1", size = 164145, upload-time = "2025-11-17T22:32:09.782Z" },
+    { url = "https://files.pythonhosted.org/packages/72/4e/1339dc6e2557a344f5ba5590872e80346f76f6cb2ac3dd16e4666e88818c/ml_dtypes-0.5.4-cp314-cp314-macosx_10_13_universal2.whl", hash = "sha256:2b857d3af6ac0d39db1de7c706e69c7f9791627209c3d6dedbfca8c7e5faec22", size = 673781, upload-time = "2025-11-17T22:32:11.364Z" },
+    { url = "https://files.pythonhosted.org/packages/04/f9/067b84365c7e83bda15bba2b06c6ca250ce27b20630b1128c435fb7a09aa/ml_dtypes-0.5.4-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:805cef3a38f4eafae3a5bf9ebdcdb741d0bcfd9e1bd90eb54abd24f928cd2465", size = 5036145, upload-time = "2025-11-17T22:32:12.783Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/bb/82c7dcf38070b46172a517e2334e665c5bf374a262f99a283ea454bece7c/ml_dtypes-0.5.4-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:14a4fd3228af936461db66faccef6e4f41c1d82fcc30e9f8d58a08916b1d811f", size = 5010230, upload-time = "2025-11-17T22:32:14.38Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/93/2bfed22d2498c468f6bcd0d9f56b033eaa19f33320389314c19ef6766413/ml_dtypes-0.5.4-cp314-cp314-win_amd64.whl", hash = "sha256:8c6a2dcebd6f3903e05d51960a8058d6e131fe69f952a5397e5dbabc841b6d56", size = 221032, upload-time = "2025-11-17T22:32:15.763Z" },
+    { url = "https://files.pythonhosted.org/packages/76/a3/9c912fe6ea747bb10fe2f8f54d027eb265db05dfb0c6335e3e063e74e6e8/ml_dtypes-0.5.4-cp314-cp314-win_arm64.whl", hash = "sha256:5a0f68ca8fd8d16583dfa7793973feb86f2fbb56ce3966daf9c9f748f52a2049", size = 163353, upload-time = "2025-11-17T22:32:16.932Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/02/48aa7d84cc30ab4ee37624a2fd98c56c02326785750cd212bc0826c2f15b/ml_dtypes-0.5.4-cp314-cp314t-macosx_10_13_universal2.whl", hash = "sha256:bfc534409c5d4b0bf945af29e5d0ab075eae9eecbb549ff8a29280db822f34f9", size = 702085, upload-time = "2025-11-17T22:32:18.175Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/e7/85cb99fe80a7a5513253ec7faa88a65306be071163485e9a626fce1b6e84/ml_dtypes-0.5.4-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:2314892cdc3fcf05e373d76d72aaa15fda9fb98625effa73c1d646f331fcecb7", size = 5355358, upload-time = "2025-11-17T22:32:19.7Z" },
+    { url = "https://files.pythonhosted.org/packages/79/2b/a826ba18d2179a56e144aef69e57fb2ab7c464ef0b2111940ee8a3a223a2/ml_dtypes-0.5.4-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0d2ffd05a2575b1519dc928c0b93c06339eb67173ff53acb00724502cda231cf", size = 5366332, upload-time = "2025-11-17T22:32:21.193Z" },
+    { url = "https://files.pythonhosted.org/packages/84/44/f4d18446eacb20ea11e82f133ea8f86e2bf2891785b67d9da8d0ab0ef525/ml_dtypes-0.5.4-cp314-cp314t-win_amd64.whl", hash = "sha256:4381fe2f2452a2d7589689693d3162e876b3ddb0a832cde7a414f8e1adf7eab1", size = 236612, upload-time = "2025-11-17T22:32:22.579Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/3f/3d42e9a78fe5edf792a83c074b13b9b770092a4fbf3462872f4303135f09/ml_dtypes-0.5.4-cp314-cp314t-win_arm64.whl", hash = "sha256:11942cbf2cf92157db91e5022633c0d9474d4dfd813a909383bd23ce828a4b7d", size = 168825, upload-time = "2025-11-17T22:32:23.766Z" },
+]
+
+[[package]]
 name = "mmh3"
 version = "5.2.1"
 source = { registry = "https://pypi.org/simple" }
@@ -2427,6 +2654,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/a2/f7/139d22fef48ac78127d18e01d80cf1be40236ae489769d17f35c3d425293/more_itertools-11.0.2.tar.gz", hash = "sha256:392a9e1e362cbc106a2457d37cabf9b36e5e12efd4ebff1654630e76597df804", size = 144659, upload-time = "2026-04-09T15:01:33.297Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/cb/98/6af411189d9413534c3eb691182bff1f5c6d44ed2f93f2edfe52a1bbceb8/more_itertools-11.0.2-py3-none-any.whl", hash = "sha256:6e35b35f818b01f691643c6c611bc0902f2e92b46c18fffa77ae1e7c46e912e4", size = 71939, upload-time = "2026-04-09T15:01:32.21Z" },
+]
+
+[[package]]
+name = "mpmath"
+version = "1.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e0/47/dd32fa426cc72114383ac549964eecb20ecfd886d1e5ccf5340b55b02f57/mpmath-1.3.0.tar.gz", hash = "sha256:7a28eb2a9774d00c7bc92411c19a89209d5da7c4c9a9e227be8330a23a25b91f", size = 508106, upload-time = "2023-03-07T16:47:11.061Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/43/e3/7d92a15f894aa0c9c4b49b8ee9ac9850d6e63b03c9c32c0367a13ae62209/mpmath-1.3.0-py3-none-any.whl", hash = "sha256:a0b2b9fe80bbcd81a6647ff13108738cfb482d481d826cc0e02f5b35e5c88d2c", size = 536198, upload-time = "2023-03-07T16:47:09.197Z" },
 ]
 
 [[package]]
@@ -2765,6 +3001,15 @@ wheels = [
 ]
 
 [[package]]
+name = "networkx"
+version = "3.6.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/6a/51/63fe664f3908c97be9d2e4f1158eb633317598cfa6e1fc14af5383f17512/networkx-3.6.1.tar.gz", hash = "sha256:26b7c357accc0c8cde558ad486283728b65b6a95d85ee1cd66bafab4c8168509", size = 2517025, upload-time = "2025-12-08T17:02:39.908Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9e/c9/b2622292ea83fbb4ec318f5b9ab867d0a28ab43c5717bb85b0a5f6b3b0a4/networkx-3.6.1-py3-none-any.whl", hash = "sha256:d47fbf302e7d9cbbb9e2555a0d267983d2aa476bac30e90dfbe5669bd57f3762", size = 2068504, upload-time = "2025-12-08T17:02:38.159Z" },
+]
+
+[[package]]
 name = "numpy"
 version = "2.4.4"
 source = { registry = "https://pypi.org/simple" }
@@ -2835,6 +3080,32 @@ wheels = [
 ]
 
 [[package]]
+name = "onnx"
+version = "1.22.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "ml-dtypes" },
+    { name = "numpy" },
+    { name = "protobuf" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/04/19/8ea73a64b368b75fe339771a20a02bc61ea1f551484c9e3d9d0bfbd0450f/onnx-1.22.0.tar.gz", hash = "sha256:ef40c0aaf0b643857ea9306fc7eddce17eaf9fb0407e4801f1fc5758443a38e0", size = 12024721, upload-time = "2026-06-15T12:50:05.354Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ee/6a/481561f1093834376ed493e4ca42a73e5be0d50031f2969c86593bdc7c96/onnx-1.22.0-cp312-abi3-macosx_12_0_universal2.whl", hash = "sha256:596fbf0490947533c1c1045ba860851dc9fb77471023dac9a71ba5b42ceab103", size = 20167081, upload-time = "2026-06-15T12:49:32.078Z" },
+    { url = "https://files.pythonhosted.org/packages/84/55/b34fc2aa30aa54b4a775402d24c4082242c720283a274fe976ac8eb94480/onnx-1.22.0-cp312-abi3-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ae5a563f281cd9d2845622cecf6c092a57e4ee1b138f66fdbbdd4200567a5e16", size = 18889249, upload-time = "2026-06-15T12:49:34.7Z" },
+    { url = "https://files.pythonhosted.org/packages/09/a6/bd32357e6cc1ecb473afd78193d7231724f284435d2db25696ecfaaa1503/onnx-1.22.0-cp312-abi3-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:955e02e1f6d385b53d52f9cd7b9cdf5caf417c300bcfe3c64c6d542be763845b", size = 19106514, upload-time = "2026-06-15T12:49:37.424Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/9d/3af461ac6c714b8b369cb71499659932f4f12cfb066250b62f7567c3d530/onnx-1.22.0-cp312-abi3-pyemscripten_2025_0_wasm32.whl", hash = "sha256:82e9f27fc1223cb06d68a56bed6f9d3caf3d0dad1b61bce45006d529b15bd94c", size = 16966387, upload-time = "2026-06-15T12:49:40.918Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/f0/68195b5e5a53e333faf2660f5352ee43738d0e42fc5216cc6b1871a9fbfb/onnx-1.22.0-cp312-abi3-win32.whl", hash = "sha256:cc8b66b312f8f03a53e268afb67180a2d97dd12cc79e2b61361c6c0073448016", size = 17081568, upload-time = "2026-06-15T12:49:43.398Z" },
+    { url = "https://files.pythonhosted.org/packages/13/a8/734725bb703c5fabb687f79c79e51249475212b3eb37771ac4a4ac9b487f/onnx-1.22.0-cp312-abi3-win_amd64.whl", hash = "sha256:72ccebab3bac07215c204ce8848d42e78eaaa666badbf72d25cd359b9f269e3a", size = 17213290, upload-time = "2026-06-15T12:49:45.933Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/2a/8ce48d8ae26a8761ad4e5dc771961b155c5c3c7c8540ec7f2f2d71b69af0/onnx-1.22.0-cp312-abi3-win_arm64.whl", hash = "sha256:f3c120dcdb70ad738f3c061b32798f408ea299eb69f84dd69ab4a6bf3c2ec01f", size = 17207030, upload-time = "2026-06-15T12:49:48.635Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/13/47323b97846387848efb1044ded11bb94b83526f3d1fbdb37c6480d4520f/onnx-1.22.0-cp314-cp314t-macosx_12_0_universal2.whl", hash = "sha256:19e45e4af88e3fe3261458d4b8cc461957ae2782a358a3560503569bf3b23b72", size = 20176465, upload-time = "2026-06-15T12:49:51.311Z" },
+    { url = "https://files.pythonhosted.org/packages/13/0c/d3b8a7e7eee123938586c608bb9894b5723f2342b9450c0eec59fbec7099/onnx-1.22.0-cp314-cp314t-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c21a0e59fd967a95b358e4a6e756d1f1eec2d304a83480f329f66e30d2bf0223", size = 18894028, upload-time = "2026-06-15T12:49:54.451Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/8a/da2a97ab46fe6e0cd9beb3ac14603a22f5be492f9ca347faf8233a07bb33/onnx-1.22.0-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:2632406b8f523ef2e2873c363f90b20a3d88c0fbcfac757d3addffccf8f452c2", size = 19110420, upload-time = "2026-06-15T12:49:57.665Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/a3/ce984063017518307ebfaa545782fc400e593dc2d7fdf4f23ce4be1ed197/onnx-1.22.0-cp314-cp314t-win_amd64.whl", hash = "sha256:a3a39fc4643867aecb33417fdddb11e308ee79d2d4a584b9d50cc7aec2091b13", size = 17237547, upload-time = "2026-06-15T12:50:00.382Z" },
+    { url = "https://files.pythonhosted.org/packages/00/50/257a880384a1dd502d543b0067945074d63cd17d0840e958355bc8197da8/onnx-1.22.0-cp314-cp314t-win_arm64.whl", hash = "sha256:8e268cdc0547e3949799ffd4a44451dc2b9080b57d0824a2db680b6ec65506f0", size = 17231391, upload-time = "2026-06-15T12:50:03.047Z" },
+]
+
+[[package]]
 name = "onnxruntime"
 version = "1.25.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2895,6 +3166,24 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/02/2e/58d83848dd1a79cb92ed8e63f6ba901ca282c5f09d04af9423ec26c56fd7/openapi_pydantic-0.5.1.tar.gz", hash = "sha256:ff6835af6bde7a459fb93eb93bb92b8749b754fc6e51b2f1590a19dc3005ee0d", size = 60892, upload-time = "2025-01-08T19:29:27.083Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/12/cf/03675d8bd8ecbf4445504d8071adab19f5f993676795708e36402ab38263/openapi_pydantic-0.5.1-py3-none-any.whl", hash = "sha256:a3a09ef4586f5bd760a8df7f43028b60cafb6d9f61de2acba9574766255ab146", size = 96381, upload-time = "2025-01-08T19:29:25.275Z" },
+]
+
+[[package]]
+name = "opencv-python"
+version = "4.13.0.92"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fc/6f/5a28fef4c4a382be06afe3938c64cc168223016fa520c5abaf37e8862aa5/opencv_python-4.13.0.92-cp37-abi3-macosx_13_0_arm64.whl", hash = "sha256:caf60c071ec391ba51ed00a4a920f996d0b64e3e46068aac1f646b5de0326a19", size = 46247052, upload-time = "2026-02-05T07:01:25.046Z" },
+    { url = "https://files.pythonhosted.org/packages/08/ac/6c98c44c650b8114a0fb901691351cfb3956d502e8e9b5cd27f4ee7fbf2f/opencv_python-4.13.0.92-cp37-abi3-macosx_14_0_x86_64.whl", hash = "sha256:5868a8c028a0b37561579bfb8ac1875babdc69546d236249fff296a8c010ccf9", size = 32568781, upload-time = "2026-02-05T07:01:41.379Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/51/82fed528b45173bf629fa44effb76dff8bc9f4eeaee759038362dfa60237/opencv_python-4.13.0.92-cp37-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:0bc2596e68f972ca452d80f444bc404e08807d021fbba40df26b61b18e01838a", size = 47685527, upload-time = "2026-02-05T06:59:11.24Z" },
+    { url = "https://files.pythonhosted.org/packages/db/07/90b34a8e2cf9c50fe8ed25cac9011cde0676b4d9d9c973751ac7616223a2/opencv_python-4.13.0.92-cp37-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:402033cddf9d294693094de5ef532339f14ce821da3ad7df7c9f6e8316da32cf", size = 70460872, upload-time = "2026-02-05T06:59:19.162Z" },
+    { url = "https://files.pythonhosted.org/packages/02/6d/7a9cc719b3eaf4377b9c2e3edeb7ed3a81de41f96421510c0a169ca3cfd4/opencv_python-4.13.0.92-cp37-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:bccaabf9eb7f897ca61880ce2869dcd9b25b72129c28478e7f2a5e8dee945616", size = 46708208, upload-time = "2026-02-05T06:59:15.419Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/55/b3b49a1b97aabcfbbd6c7326df9cb0b6fa0c0aefa8e89d500939e04aa229/opencv_python-4.13.0.92-cp37-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:620d602b8f7d8b8dab5f4b99c6eb353e78d3fb8b0f53db1bd258bb1aa001c1d5", size = 72927042, upload-time = "2026-02-05T06:59:23.389Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/17/de5458312bcb07ddf434d7bfcb24bb52c59635ad58c6e7c751b48949b009/opencv_python-4.13.0.92-cp37-abi3-win32.whl", hash = "sha256:372fe164a3148ac1ca51e5f3ad0541a4a276452273f503441d718fab9c5e5f59", size = 30932638, upload-time = "2026-02-05T07:02:14.98Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/a5/1be1516390333ff9be3a9cb648c9f33df79d5096e5884b5df71a588af463/opencv_python-4.13.0.92-cp37-abi3-win_amd64.whl", hash = "sha256:423d934c9fafb91aad38edf26efb46da91ffbc05f3f59c4b0c72e699720706f5", size = 40212062, upload-time = "2026-02-05T07:02:12.724Z" },
 ]
 
 [[package]]
@@ -3166,6 +3455,7 @@ dependencies = [
 [package.optional-dependencies]
 all = [
     { name = "deepgram-sdk" },
+    { name = "doctr-mcp" },
     { name = "elevenlabs" },
     { name = "fal-client" },
     { name = "feedparser" },
@@ -3212,6 +3502,7 @@ local = [
     { name = "pyngrok" },
 ]
 mcp = [
+    { name = "doctr-mcp" },
     { name = "mcp" },
     { name = "ms365-mcp" },
     { name = "pincer-mcps" },
@@ -3261,6 +3552,7 @@ requires-dist = [
     { name = "croniter", specifier = ">=5.0" },
     { name = "deepgram-sdk", marker = "extra == 'voice'", specifier = ">=3.0" },
     { name = "discord-py", extras = ["voice"], specifier = ">=2.3,<3.0" },
+    { name = "doctr-mcp", marker = "extra == 'mcp'", editable = "src/doctr-mcp" },
     { name = "elevenlabs", marker = "extra == 'voice'", specifier = ">=1.0" },
     { name = "fal-client", marker = "extra == 'image'", specifier = ">=0.13.0" },
     { name = "fastapi", specifier = ">=0.115.0" },
@@ -3644,6 +3936,36 @@ wheels = [
 ]
 
 [[package]]
+name = "pyclipper"
+version = "1.4.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f6/21/3c06205bb407e1f79b73b7b4dfb3950bd9537c4f625a68ab5cc41177f5bc/pyclipper-1.4.0.tar.gz", hash = "sha256:9882bd889f27da78add4dd6f881d25697efc740bf840274e749988d25496c8e1", size = 54489, upload-time = "2025-12-01T13:15:35.015Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/90/1b/7a07b68e0842324d46c03e512d8eefa9cb92ba2a792b3b4ebf939dafcac3/pyclipper-1.4.0-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:222ac96c8b8281b53d695b9c4fedc674f56d6d4320ad23f1bdbd168f4e316140", size = 265676, upload-time = "2025-12-01T13:15:04.15Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/dd/8bd622521c05d04963420ae6664093f154343ed044c53ea260a310c8bb4d/pyclipper-1.4.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:f3672dbafbb458f1b96e1ee3e610d174acb5ace5bd2ed5d1252603bb797f2fc6", size = 140458, upload-time = "2025-12-01T13:15:05.76Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/06/6e3e241882bf7d6ab23d9c69ba4e85f1ec47397cbbeee948a16cf75e21ed/pyclipper-1.4.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:d1f807e2b4760a8e5c6d6b4e8c1d71ef52b7fe1946ff088f4fa41e16a881a5ca", size = 978235, upload-time = "2025-12-01T13:15:06.993Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/f4/3418c1cd5eea640a9fa2501d4bc0b3655fa8d40145d1a4f484b987990a75/pyclipper-1.4.0-cp312-cp312-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ce1f83c9a4e10ea3de1959f0ae79e9a5bd41346dff648fee6228ba9eaf8b3872", size = 961388, upload-time = "2025-12-01T13:15:08.467Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/94/c85401d24be634af529c962dd5d781f3cb62a67cd769534df2cb3feee97a/pyclipper-1.4.0-cp312-cp312-win32.whl", hash = "sha256:3ef44b64666ebf1cb521a08a60c3e639d21b8c50bfbe846ba7c52a0415e936f4", size = 95169, upload-time = "2025-12-01T13:15:10.098Z" },
+    { url = "https://files.pythonhosted.org/packages/97/77/dfea08e3b230b82ee22543c30c35d33d42f846a77f96caf7c504dd54fab1/pyclipper-1.4.0-cp312-cp312-win_amd64.whl", hash = "sha256:d1e5498d883b706a4ce636247f0d830c6eb34a25b843a1b78e2c969754ca9037", size = 104619, upload-time = "2025-12-01T13:15:11.592Z" },
+    { url = "https://files.pythonhosted.org/packages/67/d0/cbce7d47de1e6458f66a4d999b091640134deb8f2c7351eab993b70d2e10/pyclipper-1.4.0-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:d49df13cbb2627ccb13a1046f3ea6ebf7177b5504ec61bdef87d6a704046fd6e", size = 264342, upload-time = "2025-12-01T13:15:12.697Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/cc/742b9d69d96c58ac156947e1b56d0f81cbacbccf869e2ac7229f2f86dc4e/pyclipper-1.4.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:37bfec361e174110cdddffd5ecd070a8064015c99383d95eb692c253951eee8a", size = 139839, upload-time = "2025-12-01T13:15:13.911Z" },
+    { url = "https://files.pythonhosted.org/packages/db/48/dd301d62c1529efdd721b47b9e5fb52120fcdac5f4d3405cfc0d2f391414/pyclipper-1.4.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:14c8bdb5a72004b721c4e6f448d2c2262d74a7f0c9e3076aeff41e564a92389f", size = 972142, upload-time = "2025-12-01T13:15:15.477Z" },
+    { url = "https://files.pythonhosted.org/packages/07/bf/d493fd1b33bb090fa64e28c1009374d5d72fa705f9331cd56517c35e381e/pyclipper-1.4.0-cp313-cp313-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f2a50c22c3a78cb4e48347ecf06930f61ce98cf9252f2e292aa025471e9d75b1", size = 952789, upload-time = "2025-12-01T13:15:17.042Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/88/b95ea8ea21ddca34aa14b123226a81526dd2faaa993f9aabd3ed21231604/pyclipper-1.4.0-cp313-cp313-win32.whl", hash = "sha256:c9a3faa416ff536cee93417a72bfb690d9dea136dc39a39dbbe1e5dadf108c9c", size = 94817, upload-time = "2025-12-01T13:15:18.724Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/42/0a1920d276a0e1ca21dc0d13ee9e3ba10a9a8aa3abac76cd5e5a9f503306/pyclipper-1.4.0-cp313-cp313-win_amd64.whl", hash = "sha256:d4b2d7c41086f1927d14947c563dfc7beed2f6c0d9af13c42fe3dcdc20d35832", size = 104007, upload-time = "2025-12-01T13:15:19.763Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/20/04d58c70f3ccd404f179f8dd81d16722a05a3bf1ab61445ee64e8218c1f8/pyclipper-1.4.0-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:7c87480fc91a5af4c1ba310bdb7de2f089a3eeef5fe351a3cedc37da1fcced1c", size = 265167, upload-time = "2025-12-01T13:15:20.844Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/2e/a570c1abe69b7260ca0caab4236ce6ea3661193ebf8d1bd7f78ccce537a5/pyclipper-1.4.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:81d8bb2d1fb9d66dc7ea4373b176bb4b02443a7e328b3b603a73faec088b952e", size = 139966, upload-time = "2025-12-01T13:15:22.036Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/3b/e0859e54adabdde8a24a29d3f525ebb31c71ddf2e8d93edce83a3c212ffc/pyclipper-1.4.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:773c0e06b683214dcfc6711be230c83b03cddebe8a57eae053d4603dd63582f9", size = 968216, upload-time = "2025-12-01T13:15:23.18Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/6b/e3c4febf0a35ae643ee579b09988dd931602b5bf311020535fd9e5b7e715/pyclipper-1.4.0-cp314-cp314-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9bc45f2463d997848450dbed91c950ca37c6cf27f84a49a5cad4affc0b469e39", size = 954198, upload-time = "2025-12-01T13:15:24.522Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/74/728efcee02e12acb486ce9d56fa037120c9bf5b77c54bbdbaa441c14a9d9/pyclipper-1.4.0-cp314-cp314-win32.whl", hash = "sha256:0b8c2105b3b3c44dbe1a266f64309407fe30bf372cf39a94dc8aaa97df00da5b", size = 96951, upload-time = "2025-12-01T13:15:25.79Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/d7/7f4354e69f10a917e5c7d5d72a499ef2e10945312f5e72c414a0a08d2ae4/pyclipper-1.4.0-cp314-cp314-win_amd64.whl", hash = "sha256:6c317e182590c88ec0194149995e3d71a979cfef3b246383f4e035f9d4a11826", size = 106782, upload-time = "2025-12-01T13:15:26.945Z" },
+    { url = "https://files.pythonhosted.org/packages/63/60/fc32c7a3d7f61a970511ec2857ecd09693d8ac80d560ee7b8e67a6d268c9/pyclipper-1.4.0-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:f160a2c6ba036f7eaf09f1f10f4fbfa734234af9112fb5187877efed78df9303", size = 269880, upload-time = "2025-12-01T13:15:28.117Z" },
+    { url = "https://files.pythonhosted.org/packages/49/df/c4a72d3f62f0ba03ec440c4fff56cd2d674a4334d23c5064cbf41c9583f6/pyclipper-1.4.0-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:a9f11ad133257c52c40d50de7a0ca3370a0cdd8e3d11eec0604ad3c34ba549e9", size = 141706, upload-time = "2025-12-01T13:15:30.134Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/0b/cf55df03e2175e1e2da9db585241401e0bc98f76bee3791bed39d0313449/pyclipper-1.4.0-cp314-cp314t-win32.whl", hash = "sha256:bbc827b77442c99deaeee26e0e7f172355ddb097a5e126aea206d447d3b26286", size = 105308, upload-time = "2025-12-01T13:15:31.225Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/dc/53df8b6931d47080b4fe4ee8450d42e660ee1c5c1556c7ab73359182b769/pyclipper-1.4.0-cp314-cp314t-win_amd64.whl", hash = "sha256:29dae3e0296dff8502eeb7639fcfee794b0eec8590ba3563aee28db269da6b04", size = 117608, upload-time = "2025-12-01T13:15:32.69Z" },
+]
+
+[[package]]
 name = "pycparser"
 version = "3.0"
 source = { registry = "https://pypi.org/simple" }
@@ -3850,6 +4172,35 @@ wheels = [
 ]
 
 [[package]]
+name = "pypdfium2"
+version = "5.12.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/db/42/0b51bdf50ccf13f3deb3209ca996179a49761dc191748469cf0de55b0055/pypdfium2-5.12.1.tar.gz", hash = "sha256:d0e0648fb2e28f50efcd1ec0a5a18ced9f4d66b2c227fae9b603f0a883b2d13f", size = 274428, upload-time = "2026-07-17T10:01:22.713Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/09/7e/bd8df53b1131c582f6646372047b49162032bd01628d49b9a60cd94d2181/pypdfium2-5.12.1-py3-none-android_23_arm64_v8a.whl", hash = "sha256:05bab9b1ba2de7fc299ae2af25cb9c8a0543bc8bb893e879fe8c9ba8310e9ce4", size = 3392276, upload-time = "2026-07-17T10:00:47.376Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/13/a2b71e17b0439d2af78c817a381e3557371c6c56098581da8485aef65ea6/pypdfium2-5.12.1-py3-none-android_23_armeabi_v7a.whl", hash = "sha256:d4ee061e566a6422b660cdddaaa799a2d1cbf2f016921bcaf24d61426d01d942", size = 2848776, upload-time = "2026-07-17T10:00:49.09Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/a8/d7a61700db3022792b28bce5264be90a7d2e7104998362af6b93766f50b2/pypdfium2-5.12.1-py3-none-macosx_13_0_arm64.whl", hash = "sha256:66a9ed40d70a5d728cd42148fecb9d7a0917c6161d6bb67c844093a4ed1df089", size = 3480243, upload-time = "2026-07-17T10:00:50.674Z" },
+    { url = "https://files.pythonhosted.org/packages/01/2c/d7a38fad74b6da0947cf8763aee0f8e6c9d3c12fc8e137aa615f7f8ae76c/pypdfium2-5.12.1-py3-none-macosx_13_0_x86_64.whl", hash = "sha256:847378a5ab41332998b2621b21bab2e96dc8c3eff36a08bce26695b964163983", size = 3643490, upload-time = "2026-07-17T10:00:52.236Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/29/aca739676323558595fcf8cdc8d7939d2b25aaaa6f538e829f1fee938cdd/pypdfium2-5.12.1-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:6eabf028ad8e7bc7811c9acf3a72718c180569b624b844d2c6cc974609784275", size = 3649734, upload-time = "2026-07-17T10:00:53.776Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/e0/e4ecc05f4f1a11d11c8d684a24b2fc8be8207f341be985dac301caa4f6aa/pypdfium2-5.12.1-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:7857cfa6642ec5a09db12ff8f5cf6b6494585b5e3a605399fddc4fb862837b63", size = 3380828, upload-time = "2026-07-17T10:00:55.377Z" },
+    { url = "https://files.pythonhosted.org/packages/17/1b/c94c9d486791276e736350917a11fe2cf3acba2c6c7f03f9ac0d51f8952a/pypdfium2-5.12.1-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:05bfa20a08a96584253bbe38b60e13f81a037eac31c5579e607ec1480ad25dbf", size = 3777202, upload-time = "2026-07-17T10:00:57.212Z" },
+    { url = "https://files.pythonhosted.org/packages/14/aa/7f81f0c035fc32850dfab9daf78530814f215be226dad7491e3caa0a3e8c/pypdfium2-5.12.1-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:9f059f7bdbdf4352eb83691071096940d769d6ae5930b8734237fdb1bd78fbc2", size = 4186083, upload-time = "2026-07-17T10:00:59.022Z" },
+    { url = "https://files.pythonhosted.org/packages/23/16/21420a6f2bc5f981299c336817dd5d72709dad5fda30ac38cbd5f0f7b372/pypdfium2-5.12.1-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e10cbf41b21233ec5e20adfc170cf60edd77abead86a97dc708fff55a8a886c7", size = 3701734, upload-time = "2026-07-17T10:01:00.952Z" },
+    { url = "https://files.pythonhosted.org/packages/36/a1/bb89f49e2b3ea3e945b67859d2ec6e73e722a83c006099c675692641e51d/pypdfium2-5.12.1-py3-none-manylinux_2_27_s390x.manylinux_2_28_s390x.whl", hash = "sha256:07eeebb2784f4cd38d386b924235df43217a397442796673296bb6efbdaad1d0", size = 4030403, upload-time = "2026-07-17T10:01:02.568Z" },
+    { url = "https://files.pythonhosted.org/packages/80/a7/cea5eb0c39e9c6fdf9853a3008bf021d08f962228073af90354b60c5ccdc/pypdfium2-5.12.1-py3-none-manylinux_2_34_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:5c3e6cbe43581af79526184643920ab03a9401a0c79f2226bea9d4d1e3d34008", size = 3994411, upload-time = "2026-07-17T10:01:04.25Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/43/5e470213b27c13b0d94d03d97fc3740507edadea1d1e2ce2049bfbec4aa0/pypdfium2-5.12.1-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:4648f0905441bcb141687ca2263bbf38a1aa056b943eef06019f91cff3e1da4a", size = 4993687, upload-time = "2026-07-17T10:01:05.811Z" },
+    { url = "https://files.pythonhosted.org/packages/db/da/af7972ca72f24ed720db6501333fd67bc66aa6aa5a5ec698551bd30ae62e/pypdfium2-5.12.1-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:bdff622181fab64f32328591c9c8287cdc745c9a1f2afc26ca3feba39e3e6645", size = 4534560, upload-time = "2026-07-17T10:01:07.291Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/63/06a7f2cd691f7e336cbc53fd65453fee516042c8ddb016bc50d1cd2bed45/pypdfium2-5.12.1-py3-none-musllinux_1_2_i686.whl", hash = "sha256:236dbdc88aa54f14b27937ccb2ebe3dcf08c10dbb8652f432ea982dc9af39732", size = 5237681, upload-time = "2026-07-17T10:01:08.997Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/f5/937b080671758ab0b3d3d69b2657006682e4c6a0134b36774be4ed1afcfb/pypdfium2-5.12.1-py3-none-musllinux_1_2_ppc64le.whl", hash = "sha256:9c8856ce7dd77a7827476c7d75afe1197d6cd505f5cb4167b6aacf661f3f8ea5", size = 5143027, upload-time = "2026-07-17T10:01:10.69Z" },
+    { url = "https://files.pythonhosted.org/packages/32/02/094632700c24728fa443dc89d9d1c6e4fc05bb00778b22e8482fdb133da0/pypdfium2-5.12.1-py3-none-musllinux_1_2_riscv64.whl", hash = "sha256:5f257bb40fa44ce9ba18d2c919777dbd3f16bf22548b1d68fd56c7c92f1de530", size = 4647048, upload-time = "2026-07-17T10:01:12.559Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/d0/12d84bf55a4fcf2c0ed242afc94168933194f672067e1d162aa60a8e4426/pypdfium2-5.12.1-py3-none-musllinux_1_2_s390x.whl", hash = "sha256:974082344172da76a5c3c0782eaedfe6069dbe88db77d8c671ef36b61e9b14e2", size = 5088747, upload-time = "2026-07-17T10:01:14.42Z" },
+    { url = "https://files.pythonhosted.org/packages/92/9c/92a460bac1f6cfd6f96251802b3098a804fb251dfe0b5eb004ede958ae0e/pypdfium2-5.12.1-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:715ae16b34ea1d64884d58800155179ba700e9ea65a2f583b020666acd2bfb12", size = 5049695, upload-time = "2026-07-17T10:01:15.961Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/67/53c61d366222550220b42a9212131407f49d3dbcf050178c620bf80fa899/pypdfium2-5.12.1-py3-none-win32.whl", hash = "sha256:e5358d2ce4ebc5c899aab1df9ca5d215357244e9168aa443225d3c1e649c7eac", size = 3725466, upload-time = "2026-07-17T10:01:17.773Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/c3/08b62718faf2f6b6aa49207626e3113ff3ec1b3cd076c0ef8fd852f0e57c/pypdfium2-5.12.1-py3-none-win_amd64.whl", hash = "sha256:9609be73a6701a68f29dffe0335f7a2e4b3ba581542ed65d35d49f761a4600ca", size = 3859845, upload-time = "2026-07-17T10:01:19.417Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/d5/ad551e55790134c8bc87ea16e0866a3721def0620fbfa19112c8ad4a25a6/pypdfium2-5.12.1-py3-none-win_arm64.whl", hash = "sha256:afc0b7e0c975a429abc75875209ce17b66d749f6ac5cbe8ba72470e83901e304", size = 3674605, upload-time = "2026-07-17T10:01:21.008Z" },
+]
+
+[[package]]
 name = "pyperclip"
 version = "1.11.0"
 source = { registry = "https://pypi.org/simple" }
@@ -3911,6 +4262,37 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/66/c0/0c8b6ad9f17a802ee498c46e004a0eb49bc148f2fd230864601a86dcf6db/python-dateutil-2.9.0.post0.tar.gz", hash = "sha256:37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3", size = 342432, upload-time = "2024-03-01T18:36:20.211Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ec/57/56b9bcc3c9c6a792fcbaf139543cee77261f3651ca9da0c93f5c1221264b/python_dateutil-2.9.0.post0-py2.py3-none-any.whl", hash = "sha256:a8b2bc7bffae282281c8140a97d3aa9c14da0b136dfe83f850eea9a5f7470427", size = 229892, upload-time = "2024-03-01T18:36:18.57Z" },
+]
+
+[[package]]
+name = "python-doctr"
+version = "1.0.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyascii" },
+    { name = "defusedxml" },
+    { name = "h5py" },
+    { name = "huggingface-hub" },
+    { name = "langdetect" },
+    { name = "numpy" },
+    { name = "onnx" },
+    { name = "opencv-python" },
+    { name = "pillow" },
+    { name = "pyclipper" },
+    { name = "pypdfium2" },
+    { name = "rapidfuzz" },
+    { name = "scipy" },
+    { name = "shapely" },
+    { name = "torch", version = "2.13.0", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform == 'darwin'" },
+    { name = "torch", version = "2.13.0+cpu", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "sys_platform != 'darwin'" },
+    { name = "torchvision", version = "0.28.0", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform == 'darwin'" },
+    { name = "torchvision", version = "0.28.0+cpu", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "sys_platform != 'darwin'" },
+    { name = "tqdm" },
+    { name = "validators" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/1f/aa/35afe5b4f2e601557f9a617411896df0a5e092caac44a7ab78caec1e7fcd/python_doctr-1.0.1.tar.gz", hash = "sha256:6fc54316ea7915e1fa96bf58e9434b16e1511c3c61dff16d0802f18c71a5d9c6", size = 223224, upload-time = "2026-02-04T15:05:51.862Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/03/1d/83cfd3f35e6f83553b3effc951a45813a794da2f6ffc5c0e8f3557f4cead/python_doctr-1.0.1-py3-none-any.whl", hash = "sha256:a54028bc59df98816059fb038265c787ca971098ee78a2af2514267e6c71ce7e", size = 288861, upload-time = "2026-02-04T15:05:48.783Z" },
 ]
 
 [[package]]
@@ -4035,6 +4417,69 @@ wheels = [
 [package.optional-dependencies]
 pil = [
     { name = "pillow" },
+]
+
+[[package]]
+name = "rapidfuzz"
+version = "3.14.5"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/2c/21/ef6157213316e85790041254259907eb722e00b03480256c0545d98acd33/rapidfuzz-3.14.5.tar.gz", hash = "sha256:ba10ac57884ce82112f7ed910b67e7fb6072d8ef2c06e30dc63c0f604a112e0e", size = 57901753, upload-time = "2026-04-07T11:16:31.931Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d3/e3/574435c6aafb80254c191ef40d7aca2cb2bb97a095ec9395e9fa59ac307a/rapidfuzz-3.14.5-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:0d3378f471ef440473a396ce2f8e97ee12f89a78b495540e0a5617bbfe895638", size = 1944601, upload-time = "2026-04-07T11:14:18.771Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/1f/fbad3102a255ecc112ce9a7e779bacab7fd14398217be8868dc9082ba363/rapidfuzz-3.14.5-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:1e910eebca9fd0eba245c0555e764597e8a0cccb673a92da2dc2397050725f48", size = 1164293, upload-time = "2026-04-07T11:14:20.534Z" },
+    { url = "https://files.pythonhosted.org/packages/88/37/a3eb7ff6121ed3a5f199a8c38cc86c8e481816f879cb0e0b738b078c9a7e/rapidfuzz-3.14.5-cp312-cp312-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:01550fe5f60fd176aa66b7611289d46dc4aa4b1b904874c7b6d1d54e581c5ec1", size = 1371999, upload-time = "2026-04-07T11:14:22.63Z" },
+    { url = "https://files.pythonhosted.org/packages/79/72/97a9728c711c7c1b06e107d3f0623880fb4ef90e147ed13c551a1730e7cc/rapidfuzz-3.14.5-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:48bee0b91bebfaec41e1081e351000659ab7570cc4598d617aa04d5bf827f9e6", size = 3145715, upload-time = "2026-04-07T11:14:24.508Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/54/d5caabbea233ac90c286c87c260e49d7641467e87438a18d858e41c82e91/rapidfuzz-3.14.5-cp312-cp312-manylinux_2_39_riscv64.whl", hash = "sha256:7e580cb04ad849ae9b786fa21383c6b994b6e6c1444ad1cb9f22392759d72741", size = 1456304, upload-time = "2026-04-07T11:14:26.515Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/a7/2d1a81250ac8c01a0100c026018e76f0e7a097ff63e4c553e02a6938c6fb/rapidfuzz-3.14.5-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:09d6c9ba091854f07817055d795d604179c12a8f308ba4c7d56f3719dfea1646", size = 2389089, upload-time = "2026-04-07T11:14:28.635Z" },
+    { url = "https://files.pythonhosted.org/packages/65/0d/c47c3872203ae88e6506997c0b576ad731f5261daa25d559be09c9756658/rapidfuzz-3.14.5-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:1e989f86113be66574113b9c7bdf4793f3f863d248e47d911b355e05ca6b6b10", size = 2493404, upload-time = "2026-04-07T11:14:30.577Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/2f/71e0a5a3130792146c8a200a2dd1e52aa16f7c1074012e17f2601eea9a90/rapidfuzz-3.14.5-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:0ebd1a18e2e47bc0b292a07e6ed9c3642f8aaa672d12253885f599b50807a4f9", size = 4251709, upload-time = "2026-04-07T11:14:32.451Z" },
+    { url = "https://files.pythonhosted.org/packages/86/45/d39874901abacef325adb5b34ae416817c8486dfb4fb87c7a9b74ec5b072/rapidfuzz-3.14.5-cp312-cp312-win32.whl", hash = "sha256:9981d38a703b86f0e315a3cd229fd1906fe1d91c989ed121fb975b3c849f89f5", size = 1710069, upload-time = "2026-04-07T11:14:34.37Z" },
+    { url = "https://files.pythonhosted.org/packages/85/0b/f65572c53de8a1c704bda707f63a447b67bdbe95d7cdc70d18885e191df5/rapidfuzz-3.14.5-cp312-cp312-win_amd64.whl", hash = "sha256:d8375e3da319593389727c3187ccaf3e0e84199accc530866b8e0f2b79af05e9", size = 1540630, upload-time = "2026-04-07T11:14:36.287Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/c3/143be3a578f989758cae516f3270d5cbb49783a7bfdf57cc27a670e00456/rapidfuzz-3.14.5-cp312-cp312-win_arm64.whl", hash = "sha256:478b59bb018a6780d73f33e38d0b3ec5e968a6c1ed42876b993dd456b7aa20e8", size = 813137, upload-time = "2026-04-07T11:14:38.289Z" },
+    { url = "https://files.pythonhosted.org/packages/11/66/252803f2010ba699618cdc048b6e1f7cc1f433c08b4a9a17579b92ab0142/rapidfuzz-3.14.5-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:ebd8fd343bf8492a1e60bcb6dc99f90f74f65d98d8241a6b3e1fed225b76ecd6", size = 1940205, upload-time = "2026-04-07T11:14:40.319Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/59/b2afd98e41af9cd54554a4c1c423d84cdd60e6b1c0a09496f033b55f60ec/rapidfuzz-3.14.5-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:6737b35d5af7479c5bf9710f7b17edd9d2c43128d974d25fb4ea653e42c64609", size = 1159639, upload-time = "2026-04-07T11:14:42.52Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/31/7aa7e62c4c516a7af322ed0c4f0774208b72d457d0cfec808bad0df12f4a/rapidfuzz-3.14.5-cp313-cp313-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b002c7994cc9f2bc9d9856f0fbaee6e8072c983873846c92f25cefba5b2a925f", size = 1367194, upload-time = "2026-04-07T11:14:44.25Z" },
+    { url = "https://files.pythonhosted.org/packages/90/79/2fc252a63bc91d3c3b234d0a3a6ad4ebc460037a23cdcdaf9285f986e6c9/rapidfuzz-3.14.5-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:17a34330cd2a538c1ce5d400b61ba358c5b72c654b928ff87b362e88f8b864c7", size = 3151805, upload-time = "2026-04-07T11:14:46.21Z" },
+    { url = "https://files.pythonhosted.org/packages/17/54/0c83508f2683ea70e2d05f8527eb07328acf7bb1e9d97a3bece5702378e7/rapidfuzz-3.14.5-cp313-cp313-manylinux_2_39_riscv64.whl", hash = "sha256:95d937e74c1a7a1287dfb03b62a827be08ede10a155cf1af73bbf47f2b73ee6e", size = 1455667, upload-time = "2026-04-07T11:14:47.991Z" },
+    { url = "https://files.pythonhosted.org/packages/71/1b/070175e873177814d58850a01ebe80e20ae11e93eb4da894d563988660fa/rapidfuzz-3.14.5-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:46b92a9970dcc34f0096901c792644094cab49554ac3547f35e3aebbdf0a3610", size = 2388246, upload-time = "2026-04-07T11:14:50.098Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/dd/77caf7aaf9c2be050ad1f128d7c24ff0f59079aa62c5f62f9df41c0af45e/rapidfuzz-3.14.5-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:e012177c8e8a8a0754ae0d6027d63042aa5ff036d9f40f07cb3466a6082e21b8", size = 2494333, upload-time = "2026-04-07T11:14:52.303Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/e2/dd7e1f2aa31a8fbbfc16b0610af1d770ffaf1287490f3c8c5b1c52da264f/rapidfuzz-3.14.5-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:a2ae6f53f99c9a0eca7a0afc5b4e45fc73bc1dd4ac74c00509031d76df80ed98", size = 4258579, upload-time = "2026-04-07T11:14:54.538Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/0a/ac99e1ba347ba0e85e0bb60b74231d55fb93c0eff43f2920ccb413d0be08/rapidfuzz-3.14.5-cp313-cp313-win32.whl", hash = "sha256:4a60f0057231188e3bd30216f7b4e0f279b11fa4ec818bb6c1d9f014d1562fbc", size = 1709231, upload-time = "2026-04-07T11:14:56.524Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/cb/0e251d731b3166378644238e8f0cf9e89858c024e19f75ca9f7e3ae83fd5/rapidfuzz-3.14.5-cp313-cp313-win_amd64.whl", hash = "sha256:11bfc2ed8fbe4ab86bd516fadefab126f90e6dcadffa761739fcb304707dfd35", size = 1538519, upload-time = "2026-04-07T11:14:58.635Z" },
+    { url = "https://files.pythonhosted.org/packages/30/6f/4548132acc947db6d5346a248e44a8b3a22d608ef30e770fb578caaf2d00/rapidfuzz-3.14.5-cp313-cp313-win_arm64.whl", hash = "sha256:b486b5218808f6f4dc471b114b1054e63553db69705c97da0271f47bd706aedd", size = 812628, upload-time = "2026-04-07T11:15:00.552Z" },
+    { url = "https://files.pythonhosted.org/packages/00/60/69b177577290c5eab892c6f75fe89c3aff3f9ae80298a78d9372b1cecb9a/rapidfuzz-3.14.5-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:39ef8658aaf67d51667e7bdaf7096f432333377d8302ac43c70b5df8a4cf89b8", size = 1970231, upload-time = "2026-04-07T11:15:02.603Z" },
+    { url = "https://files.pythonhosted.org/packages/48/38/2fd790052659cc4e2907b63c25433f0987864b445c1aeec1a302ef5ad948/rapidfuzz-3.14.5-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:9ad37a0be705b544af6296da8edddc260d10a8ae5462530fc9991f66498bb1f9", size = 1194394, upload-time = "2026-04-07T11:15:04.572Z" },
+    { url = "https://files.pythonhosted.org/packages/80/f4/28430ad8472fc3536e8ebd51a864a226e979cfe924c6e3f83d111373aa74/rapidfuzz-3.14.5-cp313-cp313t-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d45e06f60729e07d9b20c205f7e5cff90b6ef2584e852eecf46e045aea69627d", size = 1377051, upload-time = "2026-04-07T11:15:06.728Z" },
+    { url = "https://files.pythonhosted.org/packages/77/7e/9aeacabcfd1e77397968362e5b98fe14248b8307011136b17daf99752a8e/rapidfuzz-3.14.5-cp313-cp313t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e52da10236aa6212de71b9e170bace65b64b129c0dea7fc243d6c9ce976f5074", size = 3160565, upload-time = "2026-04-07T11:15:08.667Z" },
+    { url = "https://files.pythonhosted.org/packages/56/f4/db4dd7be0cd2f2022117ac5407d905f435d60e48baaea313a567ad27e865/rapidfuzz-3.14.5-cp313-cp313t-manylinux_2_39_riscv64.whl", hash = "sha256:440d30faaf682ca496170a7f0cc5453ec942e3e079f0fd802c9a7f938dfb50a3", size = 1442113, upload-time = "2026-04-07T11:15:11.138Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/99/0e9f6aa57f3e32a767216f797e56dc96b720fcecfb9d8ee907ecc82f8d66/rapidfuzz-3.14.5-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:56227a61fd3d17b0cd9793132431f3a3d07c8654be96794ba9f89fe0fc8b2d09", size = 2396618, upload-time = "2026-04-07T11:15:13.154Z" },
+    { url = "https://files.pythonhosted.org/packages/60/94/44a78e39ffce17cbdd3e2b53b696acc751d5d153be0f499d052b07a4d904/rapidfuzz-3.14.5-cp313-cp313t-musllinux_1_2_riscv64.whl", hash = "sha256:2e83cd2e25bb4edd97b689d9979d9c3acccdaaf26ceac08212ceece202febcfa", size = 2478220, upload-time = "2026-04-07T11:15:15.193Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/df/454311469a09a507e9d784a35796742bec22e4cebe75551e2da4e0e290fd/rapidfuzz-3.14.5-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:af3b859726cd3374287e405e14b9634563c078c5531a4f62375508addebddad1", size = 4265027, upload-time = "2026-04-07T11:15:17.28Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/01/175465a9ab3e3b70ba669058372f009d1d49c1746e2dcd56b69df188d3a5/rapidfuzz-3.14.5-cp313-cp313t-win32.whl", hash = "sha256:8ce1d850b3c0178440efde9e884d98421b5e87ff925f364d6d79e23910d7593f", size = 1766814, upload-time = "2026-04-07T11:15:19.687Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/a0/a9b84a47af06ebed94a1439eb2f02adebfb8628bcd30af1fe3e02f5ef56c/rapidfuzz-3.14.5-cp313-cp313t-win_amd64.whl", hash = "sha256:c84af70bcf34e99aee894e46a0f1ac77f17d0ef828179c387407642e2466d28a", size = 1582448, upload-time = "2026-04-07T11:15:21.98Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/f1/5937800238b3f8248e70860d79f69ba8f73e764fff47e36bc9e2f26dbcc6/rapidfuzz-3.14.5-cp313-cp313t-win_arm64.whl", hash = "sha256:aac0ad28c686a5e72b81668b906c030ee28050b244544b8af68e12fb32543895", size = 832932, upload-time = "2026-04-07T11:15:24.358Z" },
+    { url = "https://files.pythonhosted.org/packages/81/41/aa3ffb3355e62e1bf91f6599b3092e866bc88487a07c524004943c7676df/rapidfuzz-3.14.5-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:1a31cc6d7d03e7318a0974c038959c59e19c752b81115f2e9138b3331cd64d45", size = 1943327, upload-time = "2026-04-07T11:15:26.266Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/e1/c2141f1840a41e07ad2db6f724945f8f8ff3065463899a22939152dd6e09/rapidfuzz-3.14.5-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:0298d357e2bc59d572da4db0bc631009b6f8f6c9bc8c11e99a12b833f16b6575", size = 1161755, upload-time = "2026-04-07T11:15:28.659Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/07/66e753eeaa353161d1d331b7dd517bb349b0bacfebe8496d7b26be26f81f/rapidfuzz-3.14.5-cp314-cp314-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:59b3dba758661a318995655435c6ab20a04ade79fa51e75bc8dc107cac8df280", size = 1376571, upload-time = "2026-04-07T11:15:31.225Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/85/9535df0b78ba51f478c9ce7eb6d1f85535cc31fe356773b48fd9d3e563ca/rapidfuzz-3.14.5-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:4900143d82071bdda533b00300c40b14b963ff826b3642cc463b6dd0f036585e", size = 3156468, upload-time = "2026-04-07T11:15:33.428Z" },
+    { url = "https://files.pythonhosted.org/packages/81/ee/b667eb93bba6dc4e0de658edd778e1619dc4d6aab68fa5e5c7f075152735/rapidfuzz-3.14.5-cp314-cp314-manylinux_2_39_riscv64.whl", hash = "sha256:feedf219672eef83ea6be6f3bb093bba396a8560fc75be85ba225f082903df0a", size = 1458311, upload-time = "2026-04-07T11:15:35.557Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/ce/479074f5624364a48df3403c538797ef22d3ac49c19dc76c3f79fcdcc70c/rapidfuzz-3.14.5-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:419e4397a36e2665ec992d8d64c20ba4b2a42500c76ecadeca78a4f19cb9cc32", size = 2398228, upload-time = "2026-04-07T11:15:37.669Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/15/a8982f649150fffbdcd6f17565974501f6ab33b2795267bffbd4a7ba905b/rapidfuzz-3.14.5-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:97131ab2be39043054ee28d99e09efe316e6d53449b7e962dfcf3c2de8b2b246", size = 2497226, upload-time = "2026-04-07T11:15:39.857Z" },
+    { url = "https://files.pythonhosted.org/packages/19/52/5267c03ef6759831b7d4625a0c9c06e87baa2fae084b61ac9c388858317b/rapidfuzz-3.14.5-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:593c00dac4e30231c35bf3b4f1da8ec0998762e9e94425586a5d636fcd57f9d0", size = 4262283, upload-time = "2026-04-07T11:15:42.279Z" },
+    { url = "https://files.pythonhosted.org/packages/71/c0/2579f343a97f5254c43bb5853baccc01488357dcb64a27bcb869b7888a4a/rapidfuzz-3.14.5-cp314-cp314-win32.whl", hash = "sha256:0084b687b02b4e569b46d8d6d4ad25659528e6081cd6d067ca453a69035f07e4", size = 1744614, upload-time = "2026-04-07T11:15:44.498Z" },
+    { url = "https://files.pythonhosted.org/packages/17/eb/8edfed1e80119dc9c35b11df4bc701eea85622ad681fff0263b6961d3224/rapidfuzz-3.14.5-cp314-cp314-win_amd64.whl", hash = "sha256:5dfa89d78f22cd773054caff44827b846161a29f2dcf7e78b8f90d086621e502", size = 1588971, upload-time = "2026-04-07T11:15:46.86Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/04/5676df93c85cfa57a3045d8047318df9f3cd58c7b8a99340dd95f874795e/rapidfuzz-3.14.5-cp314-cp314-win_arm64.whl", hash = "sha256:67f3f9d2b444268ab53e47d31bab89954888d23c04c6789f2c727e51fe4b1d13", size = 834985, upload-time = "2026-04-07T11:15:49.411Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/0d/4a8988cea658fe335048ddef8c876addff1b6daa3c9ca8ad65a5a2196e69/rapidfuzz-3.14.5-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:77eac0526899b3c3ad1454bb2b03cdb491d67358ec8ef0c9c48bd61b632b431d", size = 1972517, upload-time = "2026-04-07T11:15:51.819Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/a3/f5cfd9965a9d9a9e32249159797c47b5d6299ea6d1629f9126b25f1c10a3/rapidfuzz-3.14.5-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:b9c6bd754d11f6e78ac54e3d86b4b11dc1ba2f13e5fc958899574532897f5a99", size = 1196056, upload-time = "2026-04-07T11:15:54.292Z" },
+    { url = "https://files.pythonhosted.org/packages/64/07/561c2e40cfd10e6630a7b0ac5a2a813aef50d944bcd1f3d260319d659d5b/rapidfuzz-3.14.5-cp314-cp314t-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:738c96944d076deeaff70e92b65696ab4f7ecb8081d7791c5403a3257dfaf8ff", size = 1374732, upload-time = "2026-04-07T11:15:56.584Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/39/123bb94fee40e2fb3b7c49b80827c7ef42d838e18def3fc2fef5a3cf817a/rapidfuzz-3.14.5-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f4c1bca487a17fe4226b4ffb2d30e799d2b274d692cffa76bd0746f56235fca3", size = 3166902, upload-time = "2026-04-07T11:15:58.768Z" },
+    { url = "https://files.pythonhosted.org/packages/75/0a/45716fafc9fd2e028cf20b5ac5bc704887081cd312f84edb0e325599414b/rapidfuzz-3.14.5-cp314-cp314t-manylinux_2_39_riscv64.whl", hash = "sha256:af6a90a4ed2a48fa1a2d17e9d824e6c7c950bea5bad0b707c77fd55751e6bfef", size = 1452130, upload-time = "2026-04-07T11:16:01.453Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/49/4e96c413114398481c0a5b0086af32c364a18613c9a2ea578d17c4bea4ee/rapidfuzz-3.14.5-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:bf5018938208d4597b2e679a4f8cff9fd252f1df53583130ae56281a21801b64", size = 2396308, upload-time = "2026-04-07T11:16:03.588Z" },
+    { url = "https://files.pythonhosted.org/packages/89/b7/49fea9fc6878d59bd259d01dd1972d9b86117992b1c66d9b16f0a65273c3/rapidfuzz-3.14.5-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:c0919d1f89ddf91129906705723118ea09754171e4116f5a5dbc667c7bc9b261", size = 2488210, upload-time = "2026-04-07T11:16:05.871Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/44/a1f732b93ffacbdad077b7c801149549b2938e1bece6addb5ad85ed74df8/rapidfuzz-3.14.5-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:93d8da883a35116d6813432177f35e570db5b0a5e30ecb0cbd7cb39c815735df", size = 4270621, upload-time = "2026-04-07T11:16:08.483Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/ce/ff942d19fce5385054650bb71a58495ddda299d94661ccc4e6e7fa44868b/rapidfuzz-3.14.5-cp314-cp314t-win32.whl", hash = "sha256:0f23e37019ec07712d58976b1ab2b889f8649a7f7c2f626a2f34ea9139e79279", size = 1803950, upload-time = "2026-04-07T11:16:10.873Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/0f/9aafc63f9661222b819b391c187eed29fc90ad5935f9690e5ecc2d2047a4/rapidfuzz-3.14.5-cp314-cp314t-win_amd64.whl", hash = "sha256:7d5ca9c7832e6879a707296d1463685f7c243a27846227044504741640caec66", size = 1632357, upload-time = "2026-04-07T11:16:13.1Z" },
+    { url = "https://files.pythonhosted.org/packages/70/a6/51fc1b0e61e3326e1c68a61cfd0c6b3c34c843681c4b1eefbf0596f59162/rapidfuzz-3.14.5-cp314-cp314t-win_arm64.whl", hash = "sha256:3e91dcd2549b8f8d843f98ba03a17e01f3d8b72ce942adbbb6761bc58ffce813", size = 855409, upload-time = "2026-04-07T11:16:15.787Z" },
 ]
 
 [[package]]
@@ -4300,12 +4745,63 @@ wheels = [
 ]
 
 [[package]]
+name = "scipy"
+version = "1.18.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a7/25/c2700dfaf6442b4effaa91af24ebce5dc9d31bb4a69706313aae70d72cd0/scipy-1.18.0.tar.gz", hash = "sha256:67b2ad2ad54c72ca6d04975a9b2df8c3638c34ddd5b28738e94fc2b57929d378", size = 30774447, upload-time = "2026-06-19T15:01:43.456Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6a/19/ca10ead60b0acc80b2b833c2c4a4f2ff753d0f58b811f70d911c7e94a25c/scipy-1.18.0-cp312-cp312-macosx_10_15_x86_64.whl", hash = "sha256:7bd21faaf5a1a3b2eff922d02db5f191b99a6518db9078a8fb23169f6d22259a", size = 31056519, upload-time = "2026-06-19T14:59:45.203Z" },
+    { url = "https://files.pythonhosted.org/packages/96/72/1e6442a00cd2924d361aa1b642ab6373ec35c6fabf311a760be9f76e0f13/scipy-1.18.0-cp312-cp312-macosx_12_0_arm64.whl", hash = "sha256:265915e79107de9f946b855e50d7470d5893ec3f54b342e1aa6201cbdcd8bb6b", size = 28681889, upload-time = "2026-06-19T14:59:48.103Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/2d/11dd93d21e147a73ba22bd75c0b9208d3a2e0ec76d53170ce7d9029b1015/scipy-1.18.0-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:9ab7b758be6940954a713ee466e2043e9f6e2ed965c1fce5c91039f4be3d90a9", size = 20423580, upload-time = "2026-06-19T14:59:50.665Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/01/93552f75e0d2a7dd115a45e59209c51e8d514daff02fc887d2623be06fe1/scipy-1.18.0-cp312-cp312-macosx_14_0_x86_64.whl", hash = "sha256:97b6cddaaee0a779ef6b5ca83c9604b27cc16b2b8fc22c142652df8793319fb8", size = 23054441, upload-time = "2026-06-19T14:59:53.564Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/23/21f5e703643d66f21faa6b4c73195bfcad70c55efcb4f1ab327cd7c4101a/scipy-1.18.0-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:52a96e21517c7292375c0e27dd796a811f03fcea5fd4d108fdfea8145dcf17ab", size = 33968720, upload-time = "2026-06-19T14:59:56.415Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/aa/1b939f6c67ed68635bb538e6752d3dacc02f66535182e939a89581a44e9c/scipy-1.18.0-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:1f55797419e16e7f30cf88ffb3113ce0467f00cfe3f70d5c281730b21769bfc2", size = 35287115, upload-time = "2026-06-19T14:59:59.411Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/ff/eec46be7e9234208f801062b53e1983085eddebd693f6c9bfb03b459830d/scipy-1.18.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:ad033410e2e0672ffdc1042110cef20e1c46f8fd0616cee1d44d8d58fad8fc11", size = 35577989, upload-time = "2026-06-19T15:00:02.235Z" },
+    { url = "https://files.pythonhosted.org/packages/84/ca/210d4759c7210bb7d269437421959b39a33434e2776b60c5cb8a763bb30a/scipy-1.18.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:4a55985d54c769c872e64b7f4c8a81cc30ef700cc04296abbbf3705439c126de", size = 37421717, upload-time = "2026-06-19T15:00:05.102Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/54/9a9edb45345bd6744da5ddfb6628e5d5185920494c6a67ec45b6381004cb/scipy-1.18.0-cp312-cp312-win_amd64.whl", hash = "sha256:71ccc8faa2dd16ac310233203474a8b5cb67f10dedd54a3116d34943f4b19132", size = 36597428, upload-time = "2026-06-19T15:00:08.112Z" },
+    { url = "https://files.pythonhosted.org/packages/99/0e/33f32a2a58987e26aec0f7df252cbbad1e90ae77bdbc76f40dd4ed0cf0ea/scipy-1.18.0-cp312-cp312-win_arm64.whl", hash = "sha256:d88363fd9d8fbd3511bd273f1a49efb2a540773ddf92a91d57498ce7dd7f3e76", size = 24351481, upload-time = "2026-06-19T15:00:11.103Z" },
+    { url = "https://files.pythonhosted.org/packages/05/52/9c0136c2de7ae0779b7b366447766cec6d9f0702c56bb8ffeb04c8fd3af4/scipy-1.18.0-cp313-cp313-macosx_10_15_x86_64.whl", hash = "sha256:09143f676d157d9f546d663504ef9c1becb819824f1afc018814176411942446", size = 31036107, upload-time = "2026-06-19T15:00:14.03Z" },
+    { url = "https://files.pythonhosted.org/packages/02/73/0291a64843270f4efb86cdcf2ee0f2048631b65ec6b405398b2b4dbf11bf/scipy-1.18.0-cp313-cp313-macosx_12_0_arm64.whl", hash = "sha256:5efe260f69417b97ddae455bfb5a95e8359f7f66ad7fa9522a60feb66f169520", size = 28663303, upload-time = "2026-06-19T15:00:16.819Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/0f/10ffa0b697a572f4e0d48b92a88895d366422f019f723e7e14a84c050dac/scipy-1.18.0-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:68363b7eaacd8b5dd426df56d782cc156468ac79a127a1b87ca597d6e2e82197", size = 20404960, upload-time = "2026-06-19T15:00:19.635Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/d2/e896cea21ba8edd6c81d4c55b1ffcc717e79698dcbebf9641b4cfb4c6622/scipy-1.18.0-cp313-cp313-macosx_14_0_x86_64.whl", hash = "sha256:c5557d8be5da8e41353fcd4d21491fdbab83b062fc579e94dc09a7c8ab4f669b", size = 23034074, upload-time = "2026-06-19T15:00:22.107Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/b2/e83ea34279a52c03374477c74006256ec78df65fc877baa4617d6de1d202/scipy-1.18.0-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0d13bca67c096d89fb95ced0d8921807300fce0275643aef9533cc63a0773468", size = 33942038, upload-time = "2026-06-19T15:00:24.964Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/af/e8fe5fb136f51e2b01678b92cb4106d10d8cd68ec147ead2e7cb0ac75398/scipy-1.18.0-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a46f9273dbd0eb1cefba61c9b8648b4dfe3cbc14a080176f9a73e44b8336dc7f", size = 35266390, upload-time = "2026-06-19T15:00:28.059Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/49/2c5cbb907b56695fc67517811d1db234dfd83381a84814ec220aded2794d/scipy-1.18.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:5aba46108853ddfc77906b6557aac839d2b52e900c1d72a1180adaaab58d265f", size = 35551324, upload-time = "2026-06-19T15:00:31.014Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/73/eda39f7a2d306ff0ffc574afd13c0bbb6d10a603d9a413998ee269487a80/scipy-1.18.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:b6f758e35f12757b5d95c00bc6de2438e229c2664b7a92e96f205959d9f2dfa4", size = 37404785, upload-time = "2026-06-19T15:00:34.072Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/d2/ae881ee28d014f38e0ccbfd974a06a919ba9af34f1f74bf42b5301891d63/scipy-1.18.0-cp313-cp313-win_amd64.whl", hash = "sha256:1afac4a847207c7ff8efd321734a50b06d0280b3b2a2c0fc2f413101747ad7c7", size = 36554943, upload-time = "2026-06-19T15:00:36.903Z" },
+    { url = "https://files.pythonhosted.org/packages/70/3a/21154e2d54eb3639c6bf4dbae2e531c68356bfe95990daa30df33b30d556/scipy-1.18.0-cp313-cp313-win_arm64.whl", hash = "sha256:c5dbddf60e58c2312316d097271a8e73d40eaf2eabfa4d95ed7d3695bbf2ce7b", size = 24350911, upload-time = "2026-06-19T15:00:40.062Z" },
+    { url = "https://files.pythonhosted.org/packages/78/b5/915a19b3de2f7430062b509653563db1633ddbb6f021b06731521115d4e2/scipy-1.18.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:4c256ee70c0d1a8a2ace807e199ccd4e3f57037433842abb3fb36bc17eaa9578", size = 31036253, upload-time = "2026-06-19T15:00:43.216Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/88/b72def7262e150d16be13fca37a96481138d624e700340bc3362a7588929/scipy-1.18.0-cp314-cp314-macosx_12_0_arm64.whl", hash = "sha256:2ef3abc54a4ffc53765374b0d5728532dfdd2585ed23f6b11c206a1f0b1b9af8", size = 28673758, upload-time = "2026-06-19T15:00:46.663Z" },
+    { url = "https://files.pythonhosted.org/packages/91/02/2e636a61a525632c373cf6a9c24442a3ffb79e364d38e98b32042964ac32/scipy-1.18.0-cp314-cp314-macosx_14_0_arm64.whl", hash = "sha256:f2a6af57bd9e4a75d70e4117e78a1bbee84f79ae3fbb6d0111005d6ebcc4cb8d", size = 20415514, upload-time = "2026-06-19T15:00:49.399Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/b6/2135974442f6aba159d9d39d774a1c8cb19947016725d69fecc685df45bf/scipy-1.18.0-cp314-cp314-macosx_14_0_x86_64.whl", hash = "sha256:3f1ac564d3bf6c03d861d2cd87a1bea0da2887136f7fb1bf519c05a8971452d6", size = 23034398, upload-time = "2026-06-19T15:00:51.941Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/e6/ba89ec5abf6ee9257c0d1ec985573f3ae32742c24bc03e016388a40b1b15/scipy-1.18.0-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:40395a5fcd1abee49a5c7aaa98c29db393eedc835138560a588c47ec16156690", size = 33998032, upload-time = "2026-06-19T15:00:54.838Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/c4/bc41eb19b0fd0db868f4132920879019318d80cc522ad8f2bca4611af808/scipy-1.18.0-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8ca01e8ae69f1b18e9a58d91afead31be3cef0dd905a10249dac559ee15460a0", size = 35283333, upload-time = "2026-06-19T15:00:58.152Z" },
+    { url = "https://files.pythonhosted.org/packages/53/a4/cbdeef6eb3830a8462a9d4ada814de5fc984345cc9ecf17cbec51a036f1e/scipy-1.18.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:7a7f3b01647384dbc3a711e8c6778e0aabbe93959249fef5c7393396bcac0867", size = 35610216, upload-time = "2026-06-19T15:01:01.155Z" },
+    { url = "https://files.pythonhosted.org/packages/80/4d/b2b82502b65f661d1b789c1665dcdf315d5f12194e06fc0b37946294ebae/scipy-1.18.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:6aa94e78ec192a30063a5e72e561c28af769dc311190b24fe91774eff1969709", size = 37418960, upload-time = "2026-06-19T15:01:04.155Z" },
+    { url = "https://files.pythonhosted.org/packages/93/3e/902d836831474b0ab5a37d16404f7bc5fafd9efba632890e271ba952635f/scipy-1.18.0-cp314-cp314-win_amd64.whl", hash = "sha256:2d8bbdc6c817f5b4006a54d799d4f5bab6f910193cbb9a1ff310833d4d270f61", size = 37288845, upload-time = "2026-06-19T15:01:07.822Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/43/8d73b337a3bdb14daa0314f0434210747c02d79d729ce1777574a817dcf6/scipy-1.18.0-cp314-cp314-win_arm64.whl", hash = "sha256:18e9575f1569b2c54174e6159d32942e03731177f63dce7975f0a0c88d102f5b", size = 24988971, upload-time = "2026-06-19T15:01:11.076Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/b4/f11918b0508a2787031a0499a03fbe3546f3bb5ca05d01038c45b278c09a/scipy-1.18.0-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:f351e0dd702687d12a402b867a1b4146a256923e1c38317cbc472f6372b94707", size = 31399325, upload-time = "2026-06-19T15:01:13.723Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/d1/1f287b57c0ff0ee5185dff3946d92c8017d39b0e431f0ae79a3ff1859512/scipy-1.18.0-cp314-cp314t-macosx_12_0_arm64.whl", hash = "sha256:7c7a51b33ce387193c97f228320cf8e87361daa1bba750638677729598b3e677", size = 29092110, upload-time = "2026-06-19T15:01:16.908Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/1a/7b74eb6c392fdcb27d414c0e7558a6d0231eb3b6d73571f479bb81ea8794/scipy-1.18.0-cp314-cp314t-macosx_14_0_arm64.whl", hash = "sha256:84031d7b052a54fae2f8632e0ec802073d385476eb9a63079bce6e23ef9283d4", size = 20833811, upload-time = "2026-06-19T15:01:20.488Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/ad/f3941716320a7b9cb4d68734a903b45fe16eff5fb7da7e16f2e619304979/scipy-1.18.0-cp314-cp314t-macosx_14_0_x86_64.whl", hash = "sha256:56abf29a7c067dde59be8b9a22d606a4ea1b2f2a4b756d9d903c62818f5dacce", size = 23396644, upload-time = "2026-06-19T15:01:23.364Z" },
+    { url = "https://files.pythonhosted.org/packages/22/22/1446b62ffe07f9719b7d9b1b6a4e05a772833ae8f441fe4c22c34c9b250f/scipy-1.18.0-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1ad44305cfa24b1ba5803cbbebf033590ccbac1aa5d612d727b785325ab408b0", size = 34079318, upload-time = "2026-06-19T15:01:26.002Z" },
+    { url = "https://files.pythonhosted.org/packages/56/3b/b87da667098bb470fa30c7011b0ba351ee976dd395c78798c66e941665a3/scipy-1.18.0-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:945c1761b93f38d7f99ae81ae80c63e621471608c7eeead563f6df025585cd58", size = 35324320, upload-time = "2026-06-19T15:01:28.881Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/a1/c7932f91909759b0267f75fdea34e91309f96b895757534b76a90b6b4344/scipy-1.18.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:1a4441f15d620578772a49e5ab48c0ee1f7a0220e387110283062729136b2553", size = 35699541, upload-time = "2026-06-19T15:01:31.968Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/86/5185061a1fcc41d18c5dc2463969b3a3964b31d9ac67b2fb05d4c7ff7670/scipy-1.18.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:9aac6192fac56bf2ca534389d24623f07b39ff83317d58287285e7fbd622ff76", size = 37472480, upload-time = "2026-06-19T15:01:35.136Z" },
+    { url = "https://files.pythonhosted.org/packages/31/8e/f04c68e39919a010d34f2ee1367fd705b0a25a02f609d755f0bfbc0a15fc/scipy-1.18.0-cp314-cp314t-win_amd64.whl", hash = "sha256:e40baea28ae7f5475c779741e2d90b1247c78531207b49c7030e698ff81cee3f", size = 37365390, upload-time = "2026-06-19T15:01:38.091Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/19/969dc072906c84dd0a3b05dcf57ea750936087d7873549e408b35cfc3f97/scipy-1.18.0-cp314-cp314t-win_arm64.whl", hash = "sha256:368e0a705903c466aa5f08eefb39e6b1b6b2d659e7352a31fd9e2438365be0f8", size = 25279661, upload-time = "2026-06-19T15:01:40.817Z" },
+]
+
+[[package]]
 name = "secretstorage"
 version = "3.5.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cryptography", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
-    { name = "jeepney", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "cryptography", marker = "sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "jeepney", marker = "sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/1c/03/e834bcd866f2f8a49a85eaff47340affa3bfa391ee9912a952a1faa68c7b/secretstorage-3.5.0.tar.gz", hash = "sha256:f04b8e4689cbce351744d5537bf6b1329c6fc68f91fa666f60a380edddcd11be", size = 19884, upload-time = "2025-11-23T19:02:53.191Z" }
 wheels = [
@@ -4322,10 +4818,70 @@ wheels = [
 ]
 
 [[package]]
+name = "setuptools"
+version = "83.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/34/26/f5d29e25ffdb535afef2d35cdb55b325298f96debd670da4c325e08d70f4/setuptools-83.0.0.tar.gz", hash = "sha256:025bccbbf0fa05b6192bc64ae1e7b16e001fd6d6d4d5de03c97b1c1ade523bef", size = 1154254, upload-time = "2026-07-04T15:31:22.699Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5d/40/e1e72872c6354b306daef1703549e8e83b4d43cfea356311bf722a043752/setuptools-83.0.0-py3-none-any.whl", hash = "sha256:29b23c360f22f414dc7336bb39178cc7bcbf6021ed2733cde173f09dba19abb3", size = 1008090, upload-time = "2026-07-04T15:31:20.885Z" },
+]
+
+[[package]]
 name = "sgmllib3k"
 version = "1.0.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/9e/bd/3704a8c3e0942d711c1299ebf7b9091930adae6675d7c8f476a7ce48653c/sgmllib3k-1.0.0.tar.gz", hash = "sha256:7868fb1c8bfa764c1ac563d3cf369c381d1325d36124933a726f29fcdaa812e9", size = 5750, upload-time = "2010-08-24T14:33:52.445Z" }
+
+[[package]]
+name = "shapely"
+version = "2.1.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/4d/bc/0989043118a27cccb4e906a46b7565ce36ca7b57f5a18b78f4f1b0f72d9d/shapely-2.1.2.tar.gz", hash = "sha256:2ed4ecb28320a433db18a5bf029986aa8afcfd740745e78847e330d5d94922a9", size = 315489, upload-time = "2025-09-24T13:51:41.432Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/24/c0/f3b6453cf2dfa99adc0ba6675f9aaff9e526d2224cbd7ff9c1a879238693/shapely-2.1.2-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:fe2533caae6a91a543dec62e8360fe86ffcdc42a7c55f9dfd0128a977a896b94", size = 1833550, upload-time = "2025-09-24T13:50:30.019Z" },
+    { url = "https://files.pythonhosted.org/packages/86/07/59dee0bc4b913b7ab59ab1086225baca5b8f19865e6101db9ebb7243e132/shapely-2.1.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:ba4d1333cc0bc94381d6d4308d2e4e008e0bd128bdcff5573199742ee3634359", size = 1643556, upload-time = "2025-09-24T13:50:32.291Z" },
+    { url = "https://files.pythonhosted.org/packages/26/29/a5397e75b435b9895cd53e165083faed5d12fd9626eadec15a83a2411f0f/shapely-2.1.2-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:0bd308103340030feef6c111d3eb98d50dc13feea33affc8a6f9fa549e9458a3", size = 2988308, upload-time = "2025-09-24T13:50:33.862Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/37/e781683abac55dde9771e086b790e554811a71ed0b2b8a1e789b7430dd44/shapely-2.1.2-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:1e7d4d7ad262a48bb44277ca12c7c78cb1b0f56b32c10734ec9a1d30c0b0c54b", size = 3099844, upload-time = "2025-09-24T13:50:35.459Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/f3/9876b64d4a5a321b9dc482c92bb6f061f2fa42131cba643c699f39317cb9/shapely-2.1.2-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:e9eddfe513096a71896441a7c37db72da0687b34752c4e193577a145c71736fc", size = 3988842, upload-time = "2025-09-24T13:50:37.478Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/a0/704c7292f7014c7e74ec84eddb7b109e1fbae74a16deae9c1504b1d15565/shapely-2.1.2-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:980c777c612514c0cf99bc8a9de6d286f5e186dcaf9091252fcd444e5638193d", size = 4152714, upload-time = "2025-09-24T13:50:39.9Z" },
+    { url = "https://files.pythonhosted.org/packages/53/46/319c9dc788884ad0785242543cdffac0e6530e4d0deb6c4862bc4143dcf3/shapely-2.1.2-cp312-cp312-win32.whl", hash = "sha256:9111274b88e4d7b54a95218e243282709b330ef52b7b86bc6aaf4f805306f454", size = 1542745, upload-time = "2025-09-24T13:50:41.414Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/bf/cb6c1c505cb31e818e900b9312d514f381fbfa5c4363edfce0fcc4f8c1a4/shapely-2.1.2-cp312-cp312-win_amd64.whl", hash = "sha256:743044b4cfb34f9a67205cee9279feaf60ba7d02e69febc2afc609047cb49179", size = 1722861, upload-time = "2025-09-24T13:50:43.35Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/90/98ef257c23c46425dc4d1d31005ad7c8d649fe423a38b917db02c30f1f5a/shapely-2.1.2-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:b510dda1a3672d6879beb319bc7c5fd302c6c354584690973c838f46ec3e0fa8", size = 1832644, upload-time = "2025-09-24T13:50:44.886Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/ab/0bee5a830d209adcd3a01f2d4b70e587cdd9fd7380d5198c064091005af8/shapely-2.1.2-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:8cff473e81017594d20ec55d86b54bc635544897e13a7cfc12e36909c5309a2a", size = 1642887, upload-time = "2025-09-24T13:50:46.735Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/5e/7d7f54ba960c13302584c73704d8c4d15404a51024631adb60b126a4ae88/shapely-2.1.2-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:fe7b77dc63d707c09726b7908f575fc04ff1d1ad0f3fb92aec212396bc6cfe5e", size = 2970931, upload-time = "2025-09-24T13:50:48.374Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/a2/83fc37e2a58090e3d2ff79175a95493c664bcd0b653dd75cb9134645a4e5/shapely-2.1.2-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:7ed1a5bbfb386ee8332713bf7508bc24e32d24b74fc9a7b9f8529a55db9f4ee6", size = 3082855, upload-time = "2025-09-24T13:50:50.037Z" },
+    { url = "https://files.pythonhosted.org/packages/44/2b/578faf235a5b09f16b5f02833c53822294d7f21b242f8e2d0cf03fb64321/shapely-2.1.2-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:a84e0582858d841d54355246ddfcbd1fce3179f185da7470f41ce39d001ee1af", size = 3979960, upload-time = "2025-09-24T13:50:51.74Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/04/167f096386120f692cc4ca02f75a17b961858997a95e67a3cb6a7bbd6b53/shapely-2.1.2-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:dc3487447a43d42adcdf52d7ac73804f2312cbfa5d433a7d2c506dcab0033dfd", size = 4142851, upload-time = "2025-09-24T13:50:53.49Z" },
+    { url = "https://files.pythonhosted.org/packages/48/74/fb402c5a6235d1c65a97348b48cdedb75fb19eca2b1d66d04969fc1c6091/shapely-2.1.2-cp313-cp313-win32.whl", hash = "sha256:9c3a3c648aedc9f99c09263b39f2d8252f199cb3ac154fadc173283d7d111350", size = 1541890, upload-time = "2025-09-24T13:50:55.337Z" },
+    { url = "https://files.pythonhosted.org/packages/41/47/3647fe7ad990af60ad98b889657a976042c9988c2807cf322a9d6685f462/shapely-2.1.2-cp313-cp313-win_amd64.whl", hash = "sha256:ca2591bff6645c216695bdf1614fca9c82ea1144d4a7591a466fef64f28f0715", size = 1722151, upload-time = "2025-09-24T13:50:57.153Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/49/63953754faa51ffe7d8189bfbe9ca34def29f8c0e34c67cbe2a2795f269d/shapely-2.1.2-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:2d93d23bdd2ed9dc157b46bc2f19b7da143ca8714464249bef6771c679d5ff40", size = 1834130, upload-time = "2025-09-24T13:50:58.49Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/ee/dce001c1984052970ff60eb4727164892fb2d08052c575042a47f5a9e88f/shapely-2.1.2-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:01d0d304b25634d60bd7cf291828119ab55a3bab87dc4af1e44b07fb225f188b", size = 1642802, upload-time = "2025-09-24T13:50:59.871Z" },
+    { url = "https://files.pythonhosted.org/packages/da/e7/fc4e9a19929522877fa602f705706b96e78376afb7fad09cad5b9af1553c/shapely-2.1.2-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:8d8382dd120d64b03698b7298b89611a6ea6f55ada9d39942838b79c9bc89801", size = 3018460, upload-time = "2025-09-24T13:51:02.08Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/18/7519a25db21847b525696883ddc8e6a0ecaa36159ea88e0fef11466384d0/shapely-2.1.2-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:19efa3611eef966e776183e338b2d7ea43569ae99ab34f8d17c2c054d3205cc0", size = 3095223, upload-time = "2025-09-24T13:51:04.472Z" },
+    { url = "https://files.pythonhosted.org/packages/48/de/b59a620b1f3a129c3fecc2737104a0a7e04e79335bd3b0a1f1609744cf17/shapely-2.1.2-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:346ec0c1a0fcd32f57f00e4134d1200e14bf3f5ae12af87ba83ca275c502498c", size = 4030760, upload-time = "2025-09-24T13:51:06.455Z" },
+    { url = "https://files.pythonhosted.org/packages/96/b3/c6655ee7232b417562bae192ae0d3ceaadb1cc0ffc2088a2ddf415456cc2/shapely-2.1.2-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:6305993a35989391bd3476ee538a5c9a845861462327efe00dd11a5c8c709a99", size = 4170078, upload-time = "2025-09-24T13:51:08.584Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/8e/605c76808d73503c9333af8f6cbe7e1354d2d238bda5f88eea36bfe0f42a/shapely-2.1.2-cp313-cp313t-win32.whl", hash = "sha256:c8876673449f3401f278c86eb33224c5764582f72b653a415d0e6672fde887bf", size = 1559178, upload-time = "2025-09-24T13:51:10.73Z" },
+    { url = "https://files.pythonhosted.org/packages/36/f7/d317eb232352a1f1444d11002d477e54514a4a6045536d49d0c59783c0da/shapely-2.1.2-cp313-cp313t-win_amd64.whl", hash = "sha256:4a44bc62a10d84c11a7a3d7c1c4fe857f7477c3506e24c9062da0db0ae0c449c", size = 1739756, upload-time = "2025-09-24T13:51:12.105Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/c4/3ce4c2d9b6aabd27d26ec988f08cb877ba9e6e96086eff81bfea93e688c7/shapely-2.1.2-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:9a522f460d28e2bf4e12396240a5fc1518788b2fcd73535166d748399ef0c223", size = 1831290, upload-time = "2025-09-24T13:51:13.56Z" },
+    { url = "https://files.pythonhosted.org/packages/17/b9/f6ab8918fc15429f79cb04afa9f9913546212d7fb5e5196132a2af46676b/shapely-2.1.2-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:1ff629e00818033b8d71139565527ced7d776c269a49bd78c9df84e8f852190c", size = 1641463, upload-time = "2025-09-24T13:51:14.972Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/57/91d59ae525ca641e7ac5551c04c9503aee6f29b92b392f31790fcb1a4358/shapely-2.1.2-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:f67b34271dedc3c653eba4e3d7111aa421d5be9b4c4c7d38d30907f796cb30df", size = 2970145, upload-time = "2025-09-24T13:51:16.961Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/cb/4948be52ee1da6927831ab59e10d4c29baa2a714f599f1f0d1bc747f5777/shapely-2.1.2-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:21952dc00df38a2c28375659b07a3979d22641aeb104751e769c3ee825aadecf", size = 3073806, upload-time = "2025-09-24T13:51:18.712Z" },
+    { url = "https://files.pythonhosted.org/packages/03/83/f768a54af775eb41ef2e7bec8a0a0dbe7d2431c3e78c0a8bdba7ab17e446/shapely-2.1.2-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:1f2f33f486777456586948e333a56ae21f35ae273be99255a191f5c1fa302eb4", size = 3980803, upload-time = "2025-09-24T13:51:20.37Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/cb/559c7c195807c91c79d38a1f6901384a2878a76fbdf3f1048893a9b7534d/shapely-2.1.2-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:cf831a13e0d5a7eb519e96f58ec26e049b1fad411fc6fc23b162a7ce04d9cffc", size = 4133301, upload-time = "2025-09-24T13:51:21.887Z" },
+    { url = "https://files.pythonhosted.org/packages/80/cd/60d5ae203241c53ef3abd2ef27c6800e21afd6c94e39db5315ea0cbafb4a/shapely-2.1.2-cp314-cp314-win32.whl", hash = "sha256:61edcd8d0d17dd99075d320a1dd39c0cb9616f7572f10ef91b4b5b00c4aeb566", size = 1583247, upload-time = "2025-09-24T13:51:23.401Z" },
+    { url = "https://files.pythonhosted.org/packages/74/d4/135684f342e909330e50d31d441ace06bf83c7dc0777e11043f99167b123/shapely-2.1.2-cp314-cp314-win_amd64.whl", hash = "sha256:a444e7afccdb0999e203b976adb37ea633725333e5b119ad40b1ca291ecf311c", size = 1773019, upload-time = "2025-09-24T13:51:24.873Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/05/a44f3f9f695fa3ada22786dc9da33c933da1cbc4bfe876fe3a100bafe263/shapely-2.1.2-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:5ebe3f84c6112ad3d4632b1fd2290665aa75d4cef5f6c5d77c4c95b324527c6a", size = 1834137, upload-time = "2025-09-24T13:51:26.665Z" },
+    { url = "https://files.pythonhosted.org/packages/52/7e/4d57db45bf314573427b0a70dfca15d912d108e6023f623947fa69f39b72/shapely-2.1.2-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:5860eb9f00a1d49ebb14e881f5caf6c2cf472c7fd38bd7f253bbd34f934eb076", size = 1642884, upload-time = "2025-09-24T13:51:28.029Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/27/4e29c0a55d6d14ad7422bf86995d7ff3f54af0eba59617eb95caf84b9680/shapely-2.1.2-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:b705c99c76695702656327b819c9660768ec33f5ce01fa32b2af62b56ba400a1", size = 3018320, upload-time = "2025-09-24T13:51:29.903Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/bb/992e6a3c463f4d29d4cd6ab8963b75b1b1040199edbd72beada4af46bde5/shapely-2.1.2-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:a1fd0ea855b2cf7c9cddaf25543e914dd75af9de08785f20ca3085f2c9ca60b0", size = 3094931, upload-time = "2025-09-24T13:51:32.699Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/16/82e65e21070e473f0ed6451224ed9fa0be85033d17e0c6e7213a12f59d12/shapely-2.1.2-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:df90e2db118c3671a0754f38e36802db75fe0920d211a27481daf50a711fdf26", size = 4030406, upload-time = "2025-09-24T13:51:34.189Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/75/c24ed871c576d7e2b64b04b1fe3d075157f6eb54e59670d3f5ffb36e25c7/shapely-2.1.2-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:361b6d45030b4ac64ddd0a26046906c8202eb60d0f9f53085f5179f1d23021a0", size = 4169511, upload-time = "2025-09-24T13:51:36.297Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/f7/b3d1d6d18ebf55236eec1c681ce5e665742aab3c0b7b232720a7d43df7b6/shapely-2.1.2-cp314-cp314t-win32.whl", hash = "sha256:b54df60f1fbdecc8ebc2c5b11870461a6417b3d617f555e5033f1505d36e5735", size = 1602607, upload-time = "2025-09-24T13:51:37.757Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/f6/f09272a71976dfc138129b8faf435d064a811ae2f708cb147dccdf7aacdb/shapely-2.1.2-cp314-cp314t-win_amd64.whl", hash = "sha256:0036ac886e0923417932c2e6369b6c52e38e0ff5d9120b90eef5cd9a5fc5cae9", size = 1796682, upload-time = "2025-09-24T13:51:39.233Z" },
+]
 
 [[package]]
 name = "shellingham"
@@ -4489,6 +5045,18 @@ wheels = [
 ]
 
 [[package]]
+name = "sympy"
+version = "1.14.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "mpmath" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/83/d3/803453b36afefb7c2bb238361cd4ae6125a569b4db67cd9e79846ba2d68c/sympy-1.14.0.tar.gz", hash = "sha256:d3d3fe8df1e5a0b42f0e7bdf50541697dbe7d23746e894990c030e2b05e72517", size = 7793921, upload-time = "2025-04-27T18:05:01.611Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a2/09/77d55d46fd61b4a135c444fc97158ef34a095e5681d0a6c10b75bf356191/sympy-1.14.0-py3-none-any.whl", hash = "sha256:e091cc3e99d2141a0ba2847328f5479b05d94a6635cb96148ccb3f34671bd8f5", size = 6299353, upload-time = "2025-04-27T18:04:59.103Z" },
+]
+
+[[package]]
 name = "tavily-python"
 version = "0.7.23"
 source = { registry = "https://pypi.org/simple" }
@@ -4589,6 +5157,144 @@ name = "tonyg-rfc3339"
 version = "0.1"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/4d/ed/9dd309dcbee8eb745d242302adae94e70e45340d91dd47887b3ef4822cd2/tonyg-rfc3339-0.1.tar.gz", hash = "sha256:e424e7b4ddf2a2f5c70d7317faecf9b69b7da099c9fc08d046c3ac679dd30d3d", size = 4756, upload-time = "2015-12-05T00:28:10.966Z" }
+
+[[package]]
+name = "torch"
+version = "2.13.0"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.15' and sys_platform == 'darwin'",
+    "python_full_version == '3.14.*' and sys_platform == 'darwin'",
+    "python_full_version == '3.13.*' and sys_platform == 'darwin'",
+    "python_full_version < '3.13' and sys_platform == 'darwin'",
+]
+dependencies = [
+    { name = "filelock", marker = "sys_platform == 'darwin'" },
+    { name = "fsspec", marker = "sys_platform == 'darwin'" },
+    { name = "jinja2", marker = "sys_platform == 'darwin'" },
+    { name = "networkx", marker = "sys_platform == 'darwin'" },
+    { name = "setuptools", marker = "sys_platform == 'darwin'" },
+    { name = "sympy", marker = "sys_platform == 'darwin'" },
+    { name = "typing-extensions", marker = "sys_platform == 'darwin'" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c4/3a/ed0f4d4d1dcde03bced7aac9a28e800abcdc0cbd06b6775044c9fbd877b7/torch-2.13.0-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:2fe228aba290d14b9f31b049be550dbd469c3fd3013d7a19705b30454da97027", size = 111213045, upload-time = "2026-07-08T16:05:22.997Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/fa/c1c10b7aff4a9a3e8956d4f0a5f468fa6db7abc3208805719076772b4833/torch-2.13.0-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:33449899ce5496c1b84b4853179d94fd102028ae1407314d9fb956bb79e70d09", size = 111213743, upload-time = "2026-07-08T16:03:28.579Z" },
+    { url = "https://files.pythonhosted.org/packages/36/76/6dcc7f0c07052102dd36f83cbc5800842a909c8c3fbf1a7f8a5844954de9/torch-2.13.0-cp314-cp314-macosx_14_0_arm64.whl", hash = "sha256:d849b390e07d8d333ce8ecaf91b273c656c598379a19c9acf1318a883f6b391c", size = 111227066, upload-time = "2026-07-08T16:03:33.6Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/ce/aa8b7f9949d32e0f2f624f342bc3b48112c1b8a130288465938bc83bcbf9/torch-2.13.0-cp314-cp314t-macosx_14_0_arm64.whl", hash = "sha256:c28def70706c2f9ecc752574766e8ae4da9b810ab6676b611166761a78a9f1e1", size = 111537025, upload-time = "2026-07-08T16:02:44.28Z" },
+]
+
+[[package]]
+name = "torch"
+version = "2.13.0+cpu"
+source = { registry = "https://download.pytorch.org/whl/cpu" }
+resolution-markers = [
+    "python_full_version >= '3.15' and sys_platform == 'win32'",
+    "python_full_version >= '3.15' and sys_platform == 'emscripten'",
+    "python_full_version >= '3.15' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version == '3.14.*' and sys_platform == 'win32'",
+    "python_full_version == '3.14.*' and sys_platform == 'emscripten'",
+    "python_full_version == '3.14.*' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version == '3.13.*' and sys_platform == 'win32'",
+    "python_full_version == '3.13.*' and sys_platform == 'emscripten'",
+    "python_full_version == '3.13.*' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version < '3.13' and sys_platform == 'win32'",
+    "python_full_version < '3.13' and sys_platform == 'emscripten'",
+    "python_full_version < '3.13' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+]
+dependencies = [
+    { name = "filelock", marker = "sys_platform != 'darwin'" },
+    { name = "fsspec", marker = "sys_platform != 'darwin'" },
+    { name = "jinja2", marker = "sys_platform != 'darwin'" },
+    { name = "networkx", marker = "sys_platform != 'darwin'" },
+    { name = "setuptools", marker = "sys_platform != 'darwin'" },
+    { name = "sympy", marker = "sys_platform != 'darwin'" },
+    { name = "typing-extensions", marker = "sys_platform != 'darwin'" },
+]
+wheels = [
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.13.0%2Bcpu-cp312-cp312-linux_s390x.whl", hash = "sha256:ffadde149901c8afa138daa38d898264003cfcf1a3336ca5cd964b5af227d867", upload-time = "2026-07-08T19:28:41Z" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.13.0%2Bcpu-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:6f307c2c32d764ffc6ff6893b801fad6d4752f3e67966cb8abf1843427c02604", upload-time = "2026-07-08T19:28:51Z" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.13.0%2Bcpu-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:4ca4a9394b0c771238a4f73590fdbbc4debad85ed0fa63d026ae1b085da7d6e2", upload-time = "2026-07-08T19:29:03Z" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.13.0%2Bcpu-cp312-cp312-win_amd64.whl", hash = "sha256:a8b450c1e58e5800e5b4691dac412f8d2d65a1dc3298166f91596603a3531e6f", upload-time = "2026-07-08T19:29:15Z" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.13.0%2Bcpu-cp312-cp312-win_arm64.whl", hash = "sha256:fa0762705b933624d59f6823db9ce7ec2e35b3e1e9c319c9db51fbeecfc3e319", upload-time = "2026-07-08T19:29:21Z" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.13.0%2Bcpu-cp313-cp313-linux_s390x.whl", hash = "sha256:966d020354f465672dc7dd10d3a5c6cd17d7eb48620aa1d265b48a1f78f06898", upload-time = "2026-07-08T19:29:30Z" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.13.0%2Bcpu-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:0b8f7d0423027ae8b90c7977c627f3379f325363a08224dffad9b4b2d684a83d", upload-time = "2026-07-08T19:29:40Z" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.13.0%2Bcpu-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:3fbf9c9d1f3c10c2d59d04aca426dee9ccc6ceb32d255c61e93acc3b4f75fae6", upload-time = "2026-07-08T19:29:54Z" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.13.0%2Bcpu-cp313-cp313-win_amd64.whl", hash = "sha256:a17ff48608634db245e17e8bb00a9558554a49aeb1e4f5fe6cd039af2a10515b", upload-time = "2026-07-08T19:30:05Z" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.13.0%2Bcpu-cp313-cp313-win_arm64.whl", hash = "sha256:ac7aaf322be4777765a53bed7264a214dd81b3a1d276b93150515a3c5f75e4b0", upload-time = "2026-07-08T19:30:12Z" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.13.0%2Bcpu-cp314-cp314-linux_s390x.whl", hash = "sha256:dec241fef3984c0d1edadd1f58708e218d4eae881ceef7bc10cf9964d41b68b9", upload-time = "2026-07-08T19:30:20Z" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.13.0%2Bcpu-cp314-cp314-manylinux_2_28_aarch64.whl", hash = "sha256:ca021f9eb2f8345c83fa03e3a04587308afb8df71bd472670b3ece00df58621c", upload-time = "2026-07-08T19:30:32Z" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.13.0%2Bcpu-cp314-cp314-manylinux_2_28_x86_64.whl", hash = "sha256:d20fa53ee744502fa4c69818a720b05ca0d37abd055d4f6e66cae155114bc691", upload-time = "2026-07-08T19:30:45Z" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.13.0%2Bcpu-cp314-cp314-win_amd64.whl", hash = "sha256:e2e5134decf00e218da62318f3dc5df156231d367871918e91eba95ab0ad43ab", upload-time = "2026-07-08T19:30:58Z" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.13.0%2Bcpu-cp314-cp314t-linux_s390x.whl", hash = "sha256:991cc14b39e751122c01f017be6448533989868731cb5eecd1006893d26787c2", upload-time = "2026-07-08T19:31:09Z" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.13.0%2Bcpu-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:7b8d26e29bceafbdaa8d63bfe7612f23875b5af2cc07e13f809c3ed890bbe1d8", upload-time = "2026-07-08T19:31:21Z" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.13.0%2Bcpu-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:b222c15a0fc2ce207d1c1a59700b46c8fa6748df1f447ad11e5c870dde0933d9", upload-time = "2026-07-08T19:31:35Z" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.13.0%2Bcpu-cp314-cp314t-win_amd64.whl", hash = "sha256:a43376bd094124ef626bfdd3d4c2c62eacb0b5ddc99776f4a32d4fd16f1f3420", upload-time = "2026-07-08T19:31:48Z" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.13.0%2Bcpu-cp315-cp315-manylinux_2_28_aarch64.whl", hash = "sha256:8eb5002ca81af00ae69b57540f615b58b8ae922b6d4848176b366a52bd2196e6", upload-time = "2026-07-08T19:32:00Z" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.13.0%2Bcpu-cp315-cp315-manylinux_2_28_x86_64.whl", hash = "sha256:1a3a35229fdc13446b4eab50e7fcf9399ff941e89a3b761497786297a5d8dde5", upload-time = "2026-07-08T19:32:16Z" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.13.0%2Bcpu-cp315-cp315t-manylinux_2_28_aarch64.whl", hash = "sha256:8e109528e6bab044815daebaf71770fbaace3a66ef1c816cb55c875350f78a60", upload-time = "2026-07-08T19:32:30Z" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.13.0%2Bcpu-cp315-cp315t-manylinux_2_28_x86_64.whl", hash = "sha256:222a6681467cc7f6f05cd3068dfbc603def3a1e46d1d4620c1c8cdf6178bd563", upload-time = "2026-07-08T19:32:44Z" },
+]
+
+[[package]]
+name = "torchvision"
+version = "0.28.0"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.15' and sys_platform == 'darwin'",
+    "python_full_version == '3.14.*' and sys_platform == 'darwin'",
+    "python_full_version == '3.13.*' and sys_platform == 'darwin'",
+    "python_full_version < '3.13' and sys_platform == 'darwin'",
+]
+dependencies = [
+    { name = "numpy", marker = "sys_platform == 'darwin'" },
+    { name = "pillow", marker = "sys_platform == 'darwin'" },
+    { name = "torch", version = "2.13.0", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform == 'darwin'" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/15/49/c1cab1ecbb3ff1a380a3f99283db1dee61b8afe354f6352c643b65937130/torchvision-0.28.0-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:e9f54c30cd52e3ef7fd034cc69b7bb7e0964e1c8f8743e018ab92e95b40f9eee", size = 1856020, upload-time = "2026-07-08T16:07:52.182Z" },
+    { url = "https://files.pythonhosted.org/packages/20/55/08a726c14c67b37c8aca04b077766909f1c7ed23f76116884fe63b9bd033/torchvision-0.28.0-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:d483b4aa3f5237569053f749cd1a2b5bb548ca456e40461a5dd087f21149d123", size = 1856021, upload-time = "2026-07-08T16:07:45.386Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/b9/da40eca5bbe9596c12ae9899ab7abaf887f5e20f29d08b924b4633714821/torchvision-0.28.0-cp314-cp314-macosx_14_0_arm64.whl", hash = "sha256:3bd9dba55224a9db4a2d77f6feaa5651770d8c8e86d3d0ddb0fa6bec54c8712b", size = 1856014, upload-time = "2026-07-08T16:07:44.282Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/80/822a6163da716f8a78141cf6678d74e26a572285d4ea866ef8aa657bb307/torchvision-0.28.0-cp314-cp314t-macosx_14_0_arm64.whl", hash = "sha256:09ce8f56e81f19b9c378ae7bb109f83f6659fd8bc3cd14241a48e4af46e9ed49", size = 1856011, upload-time = "2026-07-08T16:07:33.404Z" },
+]
+
+[[package]]
+name = "torchvision"
+version = "0.28.0+cpu"
+source = { registry = "https://download.pytorch.org/whl/cpu" }
+resolution-markers = [
+    "python_full_version >= '3.15' and sys_platform == 'win32'",
+    "python_full_version >= '3.15' and sys_platform == 'emscripten'",
+    "python_full_version >= '3.15' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version == '3.14.*' and sys_platform == 'win32'",
+    "python_full_version == '3.14.*' and sys_platform == 'emscripten'",
+    "python_full_version == '3.14.*' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version == '3.13.*' and sys_platform == 'win32'",
+    "python_full_version == '3.13.*' and sys_platform == 'emscripten'",
+    "python_full_version == '3.13.*' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version < '3.13' and sys_platform == 'win32'",
+    "python_full_version < '3.13' and sys_platform == 'emscripten'",
+    "python_full_version < '3.13' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+]
+dependencies = [
+    { name = "numpy", marker = "sys_platform != 'darwin'" },
+    { name = "pillow", marker = "sys_platform != 'darwin'" },
+    { name = "torch", version = "2.13.0+cpu", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "sys_platform != 'darwin'" },
+]
+wheels = [
+    { url = "https://download-r2.pytorch.org/whl/cpu/torchvision-0.28.0%2Bcpu-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:2f768c4f6d5adf6d5535061fd69ec44827608bac0e96e12114942a6fdfce1107", upload-time = "2026-07-08T12:26:39Z" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torchvision-0.28.0%2Bcpu-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:b545d46f4d2f9d30381281cf22874bfe1d32a8a7b0ee8396fccde89f30c6a9d9", upload-time = "2026-07-08T12:26:40Z" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torchvision-0.28.0%2Bcpu-cp312-cp312-win_amd64.whl", hash = "sha256:d88db83abbdfb97199979ec94dd427bc372c1b9ab01f0dbed20af05b0bd644b1", upload-time = "2026-07-08T12:26:40Z" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torchvision-0.28.0%2Bcpu-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:879ae6d4e2e3651582fb7187eafd535601cb5d019595d47e2c874262a000e88e", upload-time = "2026-07-08T12:26:39Z" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torchvision-0.28.0%2Bcpu-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:c6373ec4c2f922e89f45ac91889404d312ba29a31f205b0ad9a725a3894ca246", upload-time = "2026-07-08T12:26:39Z" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torchvision-0.28.0%2Bcpu-cp313-cp313-win_amd64.whl", hash = "sha256:d63eae114b4d1fca2b294d300cea3f0d6c71b6d132641e0c4cab1aa06a467b0d", upload-time = "2026-07-08T12:26:39Z" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torchvision-0.28.0%2Bcpu-cp314-cp314-manylinux_2_28_aarch64.whl", hash = "sha256:3a1a76c8decb1d7bbedd3588bccc90fb269944b7321a773db181735b42115422", upload-time = "2026-07-08T12:26:39Z" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torchvision-0.28.0%2Bcpu-cp314-cp314-manylinux_2_28_x86_64.whl", hash = "sha256:1aa741ae0eb8668b6287dd667548e2dd10179c828db68bfdee1519763b9c5b99", upload-time = "2026-07-08T12:26:39Z" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torchvision-0.28.0%2Bcpu-cp314-cp314-win_amd64.whl", hash = "sha256:d2a0171faa211b506c4dcf3a036942a41077c5d2d3d94883dafbda7b8624a3eb", upload-time = "2026-07-08T12:26:39Z" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torchvision-0.28.0%2Bcpu-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:8d8b98608779c770ede5e20609772453ebc7487ebb8697445d1856466c542f45", upload-time = "2026-07-08T12:26:39Z" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torchvision-0.28.0%2Bcpu-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:870d0d42f2eb80f4870cd35e51eea52f596a408a671b28136f06a808846f24c5", upload-time = "2026-07-08T12:26:39Z" },
+    { url = "https://download-r2.pytorch.org/whl/cpu/torchvision-0.28.0%2Bcpu-cp314-cp314t-win_amd64.whl", hash = "sha256:82dbffb63d61cd43d9c7a311588e665aa2b21173a05f852b4d384d6782fd88ef", upload-time = "2026-07-08T12:26:39Z" },
+]
 
 [[package]]
 name = "tqdm"
@@ -4764,6 +5470,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/c1/37/945b4ca0ac27e3dc4952642d4c900edd030b3da6c9634875af6e13ae80e5/uvloop-0.22.1-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b91328c72635f6f9e0282e4a57da7470c7350ab1c9f48546c0f2866205349d21", size = 4467065, upload-time = "2025-10-16T22:16:58.206Z" },
     { url = "https://files.pythonhosted.org/packages/97/cc/48d232f33d60e2e2e0b42f4e73455b146b76ebe216487e862700457fbf3c/uvloop-0.22.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:daf620c2995d193449393d6c62131b3fbd40a63bf7b307a1527856ace637fe88", size = 4328384, upload-time = "2025-10-16T22:16:59.36Z" },
     { url = "https://files.pythonhosted.org/packages/e4/16/c1fd27e9549f3c4baf1dc9c20c456cd2f822dbf8de9f463824b0c0357e06/uvloop-0.22.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:6cde23eeda1a25c75b2e07d39970f3374105d5eafbaab2a4482be82f272d5a5e", size = 4296730, upload-time = "2025-10-16T22:17:00.744Z" },
+]
+
+[[package]]
+name = "validators"
+version = "0.35.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/53/66/a435d9ae49850b2f071f7ebd8119dd4e84872b01630d6736761e6e7fd847/validators-0.35.0.tar.gz", hash = "sha256:992d6c48a4e77c81f1b4daba10d16c3a9bb0dbb79b3a19ea847ff0928e70497a", size = 73399, upload-time = "2025-05-01T05:42:06.7Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fa/6e/3e955517e22cbdd565f2f8b2e73d52528b14b8bcfdb04f62466b071de847/validators-0.35.0-py3-none-any.whl", hash = "sha256:e8c947097eae7892cb3d26868d637f79f47b4a0554bc6b80065dfe5aac3705dd", size = 44712, upload-time = "2025-05-01T05:42:04.203Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -1029,6 +1029,7 @@ name = "doctr-mcp"
 version = "0.1.0"
 source = { editable = "src/doctr-mcp" }
 dependencies = [
+    { name = "fastapi" },
     { name = "fastmcp" },
     { name = "pillow" },
     { name = "pydantic" },
@@ -1055,6 +1056,7 @@ telemetry = [
 
 [package.metadata]
 requires-dist = [
+    { name = "fastapi", specifier = ">=0.115.0" },
     { name = "fastmcp", specifier = "==3.2.4" },
     { name = "httpx", marker = "extra == 'dev'", specifier = ">=0.27.0" },
     { name = "pillow", specifier = ">=10.1.0" },
@@ -4800,8 +4802,8 @@ name = "secretstorage"
 version = "3.5.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cryptography", marker = "sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32'" },
-    { name = "jeepney", marker = "sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "cryptography" },
+    { name = "jeepney" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/1c/03/e834bcd866f2f8a49a85eaff47340affa3bfa391ee9912a952a1faa68c7b/secretstorage-3.5.0.tar.gz", hash = "sha256:f04b8e4689cbce351744d5537bf6b1329c6fc68f91fa666f60a380edddcd11be", size = 19884, upload-time = "2025-11-23T19:02:53.191Z" }
 wheels = [
@@ -5169,13 +5171,13 @@ resolution-markers = [
     "python_full_version < '3.13' and sys_platform == 'darwin'",
 ]
 dependencies = [
-    { name = "filelock", marker = "sys_platform == 'darwin'" },
-    { name = "fsspec", marker = "sys_platform == 'darwin'" },
-    { name = "jinja2", marker = "sys_platform == 'darwin'" },
-    { name = "networkx", marker = "sys_platform == 'darwin'" },
-    { name = "setuptools", marker = "sys_platform == 'darwin'" },
-    { name = "sympy", marker = "sys_platform == 'darwin'" },
-    { name = "typing-extensions", marker = "sys_platform == 'darwin'" },
+    { name = "filelock" },
+    { name = "fsspec" },
+    { name = "jinja2" },
+    { name = "networkx" },
+    { name = "setuptools" },
+    { name = "sympy" },
+    { name = "typing-extensions" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c4/3a/ed0f4d4d1dcde03bced7aac9a28e800abcdc0cbd06b6775044c9fbd877b7/torch-2.13.0-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:2fe228aba290d14b9f31b049be550dbd469c3fd3013d7a19705b30454da97027", size = 111213045, upload-time = "2026-07-08T16:05:22.997Z" },
@@ -5203,13 +5205,13 @@ resolution-markers = [
     "python_full_version < '3.13' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32'",
 ]
 dependencies = [
-    { name = "filelock", marker = "sys_platform != 'darwin'" },
-    { name = "fsspec", marker = "sys_platform != 'darwin'" },
-    { name = "jinja2", marker = "sys_platform != 'darwin'" },
-    { name = "networkx", marker = "sys_platform != 'darwin'" },
-    { name = "setuptools", marker = "sys_platform != 'darwin'" },
-    { name = "sympy", marker = "sys_platform != 'darwin'" },
-    { name = "typing-extensions", marker = "sys_platform != 'darwin'" },
+    { name = "filelock" },
+    { name = "fsspec" },
+    { name = "jinja2" },
+    { name = "networkx" },
+    { name = "setuptools" },
+    { name = "sympy" },
+    { name = "typing-extensions" },
 ]
 wheels = [
     { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.13.0%2Bcpu-cp312-cp312-linux_s390x.whl", hash = "sha256:ffadde149901c8afa138daa38d898264003cfcf1a3336ca5cd964b5af227d867", upload-time = "2026-07-08T19:28:41Z" },
@@ -5247,9 +5249,9 @@ resolution-markers = [
     "python_full_version < '3.13' and sys_platform == 'darwin'",
 ]
 dependencies = [
-    { name = "numpy", marker = "sys_platform == 'darwin'" },
-    { name = "pillow", marker = "sys_platform == 'darwin'" },
-    { name = "torch", version = "2.13.0", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform == 'darwin'" },
+    { name = "numpy" },
+    { name = "pillow" },
+    { name = "torch", version = "2.13.0", source = { registry = "https://pypi.org/simple" } },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/15/49/c1cab1ecbb3ff1a380a3f99283db1dee61b8afe354f6352c643b65937130/torchvision-0.28.0-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:e9f54c30cd52e3ef7fd034cc69b7bb7e0964e1c8f8743e018ab92e95b40f9eee", size = 1856020, upload-time = "2026-07-08T16:07:52.182Z" },
@@ -5277,9 +5279,9 @@ resolution-markers = [
     "python_full_version < '3.13' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'win32'",
 ]
 dependencies = [
-    { name = "numpy", marker = "sys_platform != 'darwin'" },
-    { name = "pillow", marker = "sys_platform != 'darwin'" },
-    { name = "torch", version = "2.13.0+cpu", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "sys_platform != 'darwin'" },
+    { name = "numpy" },
+    { name = "pillow" },
+    { name = "torch", version = "2.13.0+cpu", source = { registry = "https://download.pytorch.org/whl/cpu" } },
 ]
 wheels = [
     { url = "https://download-r2.pytorch.org/whl/cpu/torchvision-0.28.0%2Bcpu-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:2f768c4f6d5adf6d5535061fd69ec44827608bac0e96e12114942a6fdfce1107", upload-time = "2026-07-08T12:26:39Z" },


### PR DESCRIPTION
New bundled MCP server with 6 tools (OCR, detection, recognition, KIE, architecture discovery), a lazy bounded-LRU predictor cache, Docker/compose setup, and a mocked test suite. Wired into pyproject.toml, pincer.toml, docker-compose.yml, CI, and docs.

Closes #168 