### PR TITLE
Add [identity] TOML section to pincer.toml as an alternative to PINCE…

### DIFF
--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -252,6 +252,38 @@ PINCER_IDENTITY_MAP=telegram:12345=whatsapp:491234567890
 
 The optional `name@` prefix sets the `pincer_user_id` used as the memory tag (e.g. `user:john`). Named IDs are stable across DB rebuilds; hash IDs (`usr_abc123...`) are auto-generated and opaque. Channel-specific identifiers (email addresses for Slack, phone numbers for WhatsApp, @usernames for Telegram) are resolved to internal IDs by each channel driver at startup before being stored.
 
+#### TOML alternative for large rosters
+
+For a roster too large to comfortably manage as one `PINCER_IDENTITY_MAP` string, the same mapping can be expressed as an `[identity]` section in `pincer.toml` / `pincer.local.toml` instead — one table per person, keyed by their `pincer_user_id`:
+
+```toml
+[identity.johndoe]
+display_name      = "John Doe"
+email             = "john.doe@domain.tld"
+timezone          = "Europe/Berlin"
+preferred_channel = "telegram"
+
+[[identity.johndoe.channels]]
+channel         = "telegram"
+channel_user_id = 123456
+
+[identity.jane]
+display_name      = "Jane Austin"
+preferred_channel = "whatsapp"
+
+[[identity.jane.channels]]
+channel         = "telegram"
+channel_user_id = "janeAustin"
+
+[[identity.jane.channels]]
+channel         = "whatsapp"
+channel_user_id = "491111111111"
+```
+
+Unlike `PINCER_IDENTITY_MAP`, a person may have just one `[[...channels]]` entry — useful for pre-registering a roster incrementally as new channel IDs become known. `pincer.local.toml`'s `[identity]` section merges into `pincer.toml`'s per person, per field, appending new person keys and leaving unspecified fields inherited from the base entry — see [Local overrides — pincer.local.toml](../guides/mcp-guide.md#local-overrides--pincerlocaltoml) for the same merge pattern applied to `[[mcp.servers]]`. As with those entries, `channels` is replaced wholesale by an override rather than merged per-channel.
+
+**`PINCER_IDENTITY_MAP`, when set (non-empty), always fully overrides the TOML `[identity]` section** — the two are not merged; the TOML section is simply ignored while the env var is set.
+
 ## API Endpoints
 
 The API server starts automatically with `pincer run` on the configured

--- a/pincer.toml
+++ b/pincer.toml
@@ -211,3 +211,19 @@ approval_required = ["!*"]
 # at startup), so the default startup_timeout is fine — but per-call inference on
 # CPU is slower than this repo's other bundled servers, hence the longer timeout.
 timeout = 120
+
+# ── Cross-channel identity ─────────────────────────────────────────────────
+# Alternative to PINCER_IDENTITY_MAP for rosters too large for one env-var
+# string — one [identity.<key>] table per person, <key> becomes their
+# pincer_user_id. PINCER_IDENTITY_MAP, if set, fully overrides this section.
+# Put real names/IDs in pincer.local.toml (gitignored), not here.
+#
+# [identity.johndoe]
+# display_name      = "John Doe"
+# email             = "john.doe@domain.tld"
+# timezone          = "Europe/Berlin"
+# preferred_channel = "telegram"
+#
+# [[identity.johndoe.channels]]
+# channel         = "telegram"
+# channel_user_id = 123456

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ dependencies = [
     # WhatsApp frequently invalidates older protocol versions; keep floor at a
     # release that carries a known-accepted whatsmeow build. Bump when the
     # server returns `err-client-outdated` (see docs/whatsapp-troubleshooting.md).
-    "neonize>=0.3.17",
+    "neonize>=0.4.3",
     # neonize 0.3.16 ships protobuf gencode 7.34.1 without pinning a runtime
     # floor; older protobuf runtimes raise `incompatible Protobuf Gencode/Runtime
     # versions` at pairing time. Keep this aligned with neonize's gencode.

--- a/src/pincer/api/identity.py
+++ b/src/pincer/api/identity.py
@@ -38,7 +38,7 @@ async def list_identities(
                 async with db.execute(
                     """
                     SELECT DISTINCT m.pincer_user_id, m.preferred_channel, m.display_name, m.created_at,
-                        m.active_channel, m.active_channel_updated_at
+                        m.active_channel, m.active_channel_updated_at, m.timezone
                     FROM identity_meta m
                     LEFT JOIN channel_identities ci ON ci.pincer_user_id = m.pincer_user_id
                     WHERE m.pincer_user_id LIKE ? OR ci.channel_user_id LIKE ?
@@ -52,7 +52,7 @@ async def list_identities(
                 async with db.execute(
                     """
                     SELECT pincer_user_id, preferred_channel, display_name, created_at,
-                        active_channel, active_channel_updated_at
+                        active_channel, active_channel_updated_at, timezone
                     FROM identity_meta
                     ORDER BY created_at
                     LIMIT ?
@@ -89,6 +89,7 @@ async def list_identities(
                         "active_channel": meta["active_channel"],
                         "active_channel_updated_at": meta["active_channel_updated_at"],
                         "display_name": meta["display_name"],
+                        "timezone": meta["timezone"],
                         "created_at": meta["created_at"],
                         "channels": channels,
                     }
@@ -115,7 +116,7 @@ async def get_identity(pincer_user_id: str) -> dict[str, Any]:
 
             async with db.execute(
                 "SELECT pincer_user_id, preferred_channel, display_name, created_at, "
-                "active_channel, active_channel_updated_at "
+                "active_channel, active_channel_updated_at, timezone "
                 "FROM identity_meta WHERE pincer_user_id = ?",
                 (pincer_user_id,),
             ) as cur:
@@ -153,6 +154,7 @@ async def get_identity(pincer_user_id: str) -> dict[str, Any]:
         "active_channel": meta["active_channel"],
         "active_channel_updated_at": meta["active_channel_updated_at"],
         "display_name": meta["display_name"],
+        "timezone": meta["timezone"],
         "created_at": meta["created_at"],
         "channels": channels,
     }

--- a/src/pincer/api/identity.py
+++ b/src/pincer/api/identity.py
@@ -38,7 +38,7 @@ async def list_identities(
                 async with db.execute(
                     """
                     SELECT DISTINCT m.pincer_user_id, m.preferred_channel, m.display_name, m.created_at,
-                        m.active_channel, m.active_channel_updated_at, m.timezone
+                        m.active_channel, m.active_channel_updated_at, m.timezone, m.email
                     FROM identity_meta m
                     LEFT JOIN channel_identities ci ON ci.pincer_user_id = m.pincer_user_id
                     WHERE m.pincer_user_id LIKE ? OR ci.channel_user_id LIKE ?
@@ -52,7 +52,7 @@ async def list_identities(
                 async with db.execute(
                     """
                     SELECT pincer_user_id, preferred_channel, display_name, created_at,
-                        active_channel, active_channel_updated_at, timezone
+                        active_channel, active_channel_updated_at, timezone, email
                     FROM identity_meta
                     ORDER BY created_at
                     LIMIT ?
@@ -90,6 +90,7 @@ async def list_identities(
                         "active_channel_updated_at": meta["active_channel_updated_at"],
                         "display_name": meta["display_name"],
                         "timezone": meta["timezone"],
+                        "email": meta["email"],
                         "created_at": meta["created_at"],
                         "channels": channels,
                     }
@@ -116,7 +117,7 @@ async def get_identity(pincer_user_id: str) -> dict[str, Any]:
 
             async with db.execute(
                 "SELECT pincer_user_id, preferred_channel, display_name, created_at, "
-                "active_channel, active_channel_updated_at, timezone "
+                "active_channel, active_channel_updated_at, timezone, email "
                 "FROM identity_meta WHERE pincer_user_id = ?",
                 (pincer_user_id,),
             ) as cur:
@@ -155,6 +156,7 @@ async def get_identity(pincer_user_id: str) -> dict[str, Any]:
         "active_channel_updated_at": meta["active_channel_updated_at"],
         "display_name": meta["display_name"],
         "timezone": meta["timezone"],
+        "email": meta["email"],
         "created_at": meta["created_at"],
         "channels": channels,
     }

--- a/src/pincer/channels/whatsapp.py
+++ b/src/pincer/channels/whatsapp.py
@@ -72,7 +72,7 @@ MAX_WHATSAPP_MESSAGE_LENGTH = 4096
 # (2=LOGGED_OUT, 3=TEMP_BANNED, 4=MAIN_DEVICE_GONE, 6=CLIENT_OUTDATED, 7=BAD_USER_AGENT)
 _WA_CLIENT_OUTDATED_ACTION = (
     "WhatsApp rejected the client protocol version. "
-    "Run `uv pip install -U 'neonize>=0.3.16'` (or `pip install -U neonize`) and restart. "
+    "Run `uv pip install -U 'neonize>=0.4.3'` (or `pip install -U neonize`) and restart. "
     "See docs/whatsapp-troubleshooting.md if already on the latest neonize."
 )
 _WA_LOGGED_OUT_ACTION = (

--- a/src/pincer/cli.py
+++ b/src/pincer/cli.py
@@ -830,9 +830,11 @@ async def _run_agent(settings: Settings) -> None:
 
     # Sprint 3: Identity resolver
     from pincer.channels.middleware import IdentityMiddleware, build_pipeline
+    from pincer.config.identity import resolve_identity_map_config
     from pincer.core.identity import IdentityResolver
 
-    identity = IdentityResolver(settings.db_path, settings.identity_map)
+    identity_map_config, identity_profiles = resolve_identity_map_config(settings.identity_map)
+    identity = IdentityResolver(settings.db_path, identity_map_config, identity_profiles)
     await identity.ensure_table()
 
     _identity_pipeline = build_pipeline(IdentityMiddleware(identity))

--- a/src/pincer/config/identity.py
+++ b/src/pincer/config/identity.py
@@ -124,7 +124,10 @@ def load_identity_config(config_dir: Path | None = None) -> dict[str, IdentityTo
             except ValueError as e:
                 raise ValueError(f"identity.{person_key}: unknown channel '{channel}'") from e
 
-            channel_user_id = str(channel_user_id_raw)
+            channel_user_id = str(channel_user_id_raw).strip()
+            if not channel_user_id:
+                raise ValueError(f"identity.{person_key}: channel '{channel}' has an empty channel_user_id")
+
             pair = (channel, channel_user_id)
             if pair in seen_pairs:
                 raise ValueError(

--- a/src/pincer/config/identity.py
+++ b/src/pincer/config/identity.py
@@ -135,9 +135,7 @@ def load_identity_config(config_dir: Path | None = None) -> dict[str, IdentityTo
             channels.append(pair)
 
         if not channels:
-            raise ValueError(
-                f"identity.{person_key}: needs at least one [[identity.{person_key}.channels]] entry"
-            )
+            raise ValueError(f"identity.{person_key}: needs at least one [[identity.{person_key}.channels]] entry")
 
         entries[person_key] = IdentityTomlEntry(
             pincer_user_id=person_key,

--- a/src/pincer/config/identity.py
+++ b/src/pincer/config/identity.py
@@ -1,0 +1,180 @@
+"""Cross-channel identity configuration — loaded from pincer.toml / pincer.local.toml.
+
+An alternative to `PINCER_IDENTITY_MAP` (see `pincer.core.identity` module
+docstring) for rosters too large to comfortably manage as one env-var string.
+
+Priority (highest to lowest):
+1. PINCER_IDENTITY_MAP, if non-empty — TOML is not even read in that case.
+2. pincer.local.toml's [identity] section (optional — overrides/extends pincer.toml)
+3. pincer.toml's [identity] section
+
+This is a deliberate divergence from `pincer.mcp.config.load_mcp_config`'s
+field-level env > local.toml > toml merge: here the env var, when set, fully
+replaces the TOML section rather than merging with it.
+
+Schema — one person per `[identity.<key>]` table, `<key>` becomes the
+`pincer_user_id`:
+
+    [identity.johndoe]
+    display_name      = "John Doe"
+    email             = "john.doe@domain.tld"
+    timezone          = "Europe/Berlin"
+    preferred_channel = "telegram"
+
+    [[identity.johndoe.channels]]
+    channel         = "telegram"
+    channel_user_id = 123456
+
+Unlike `PINCER_IDENTITY_MAP`, a person may have just one `[[...channels]]`
+entry — useful for pre-registering a roster incrementally as new channel IDs
+become known.
+
+Entries are converted into `PINCER_IDENTITY_MAP`'s own string grammar
+(`name@ch1:id1=ch2:id2...`) so `IdentityResolver._parse_mapping` and its
+callers need no changes. `email`/`timezone` have no slot in that grammar, so
+they're returned separately as a `pincer_user_id -> (email, timezone)` dict —
+see `resolve_identity_map_config`.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+from pincer.channels.base import ChannelType
+from pincer.config.toml_loader import read_toml_raw
+from pincer.core.identity import IdentityProfile
+
+_KEY_PATTERN = re.compile(r"^[a-zA-Z0-9_]+$")
+
+
+@dataclass(frozen=True)
+class IdentityTomlEntry:
+    """One `[identity.<key>]` entry parsed from pincer.toml / pincer.local.toml."""
+
+    pincer_user_id: str
+    display_name: str | None = None
+    preferred_channel: str | None = None
+    email: str | None = None
+    timezone: str | None = None
+    channels: list[tuple[str, str]] = field(default_factory=list)
+
+
+def _merge_identity_raw(base: dict[str, Any], override: dict[str, Any]) -> dict[str, Any]:
+    """Merge two raw [identity] section dicts, keyed by person (TOML table key).
+
+    An override person with the same key as a base person is merged field by
+    field: override wins per key, fields absent from the override are
+    inherited from the base entry. `channels` is one such field — supplying
+    it in the override replaces the base person's whole channel list rather
+    than merging per-channel. New person-keys not present in base are
+    appended, in order.
+    """
+    merged: dict[str, Any] = dict(base)
+    for person_key, override_person in override.items():
+        base_person = merged.get(person_key, {})
+        merged[person_key] = {**base_person, **override_person}
+    return merged
+
+
+def load_identity_config(config_dir: Path | None = None) -> dict[str, IdentityTomlEntry]:
+    """Load and merge the [identity] section from pincer.toml + pincer.local.toml.
+
+    Returns entries keyed by pincer_user_id, in TOML definition order.
+    Raises ValueError on an invalid person key, an unknown channel, or a
+    (channel, channel_user_id) pair reused across two different people —
+    config mistakes should fail loudly at startup, not be silently absorbed.
+    """
+    base_dir = config_dir or Path.cwd()
+    base_raw = read_toml_raw(base_dir / "pincer.toml")
+    local_raw = read_toml_raw(base_dir / "pincer.local.toml")
+
+    identity_raw: dict[str, Any] = dict((base_raw or {}).get("identity", {}))
+    if local_raw:
+        local_identity = local_raw.get("identity")
+        if local_identity:
+            identity_raw = _merge_identity_raw(identity_raw, local_identity)
+
+    entries: dict[str, IdentityTomlEntry] = {}
+    seen_pairs: dict[tuple[str, str], str] = {}
+
+    for person_key, person_raw in identity_raw.items():
+        if not _KEY_PATTERN.match(person_key):
+            raise ValueError(f"identity key must be alphanumeric/underscore: '{person_key}'")
+
+        preferred_channel = person_raw.get("preferred_channel")
+        if preferred_channel is not None:
+            try:
+                ChannelType(preferred_channel)
+            except ValueError as e:
+                raise ValueError(f"identity.{person_key}: unknown preferred_channel '{preferred_channel}'") from e
+
+        channels: list[tuple[str, str]] = []
+        for ch_raw in person_raw.get("channels", []):
+            channel = ch_raw["channel"]
+            try:
+                ChannelType(channel)
+            except ValueError as e:
+                raise ValueError(f"identity.{person_key}: unknown channel '{channel}'") from e
+
+            channel_user_id = str(ch_raw["channel_user_id"])
+            pair = (channel, channel_user_id)
+            if pair in seen_pairs:
+                raise ValueError(
+                    f"identity.{person_key}: channel:id '{channel}:{channel_user_id}' "
+                    f"is already used by identity.{seen_pairs[pair]}"
+                )
+            seen_pairs[pair] = person_key
+            channels.append(pair)
+
+        entries[person_key] = IdentityTomlEntry(
+            pincer_user_id=person_key,
+            display_name=person_raw.get("display_name"),
+            preferred_channel=preferred_channel,
+            email=person_raw.get("email"),
+            timezone=person_raw.get("timezone"),
+            channels=channels,
+        )
+
+    return entries
+
+
+def _stringify_entry(entry: IdentityTomlEntry) -> str:
+    pairs = "=".join(f"{ch}:{cid}" for ch, cid in entry.channels)
+    return f"{entry.pincer_user_id}@{pairs}"
+
+
+def resolve_identity_map_config(
+    env_value: str,
+    config_dir: Path | None = None,
+) -> tuple[str, dict[str, IdentityProfile]]:
+    """Resolve the effective identity-map config for `IdentityResolver`.
+
+    Returns (identity_map_config, profiles):
+    - identity_map_config: a string in PINCER_IDENTITY_MAP's own grammar,
+      ready to pass straight to `IdentityResolver`.
+    - profiles: pincer_user_id -> IdentityProfile, carrying the fields that
+      grammar has no room for (display_name, preferred_channel, email,
+      timezone). Always empty when PINCER_IDENTITY_MAP is used, since that
+      grammar has no field for any of these.
+
+    PINCER_IDENTITY_MAP, when non-empty, is returned as-is — the TOML
+    [identity] section is not even read in that case.
+    """
+    if env_value:
+        return env_value, {}
+
+    entries = load_identity_config(config_dir)
+    identity_map_config = ",".join(_stringify_entry(entry) for entry in entries.values())
+    profiles = {
+        entry.pincer_user_id: IdentityProfile(
+            display_name=entry.display_name,
+            preferred_channel=entry.preferred_channel,
+            email=entry.email,
+            timezone=entry.timezone,
+        )
+        for entry in entries.values()
+    }
+    return identity_map_config, profiles

--- a/src/pincer/config/identity.py
+++ b/src/pincer/config/identity.py
@@ -113,13 +113,18 @@ def load_identity_config(config_dir: Path | None = None) -> dict[str, IdentityTo
 
         channels: list[tuple[str, str]] = []
         for ch_raw in person_raw.get("channels", []):
-            channel = ch_raw["channel"]
+            try:
+                channel = ch_raw["channel"]
+                channel_user_id_raw = ch_raw["channel_user_id"]
+            except KeyError as e:
+                raise ValueError(f"identity.{person_key}: channel entry missing {e.args[0]!r}") from e
+
             try:
                 ChannelType(channel)
             except ValueError as e:
                 raise ValueError(f"identity.{person_key}: unknown channel '{channel}'") from e
 
-            channel_user_id = str(ch_raw["channel_user_id"])
+            channel_user_id = str(channel_user_id_raw)
             pair = (channel, channel_user_id)
             if pair in seen_pairs:
                 raise ValueError(
@@ -128,6 +133,11 @@ def load_identity_config(config_dir: Path | None = None) -> dict[str, IdentityTo
                 )
             seen_pairs[pair] = person_key
             channels.append(pair)
+
+        if not channels:
+            raise ValueError(
+                f"identity.{person_key}: needs at least one [[identity.{person_key}.channels]] entry"
+            )
 
         entries[person_key] = IdentityTomlEntry(
             pincer_user_id=person_key,

--- a/src/pincer/config/toml_loader.py
+++ b/src/pincer/config/toml_loader.py
@@ -1,0 +1,33 @@
+"""Shared raw-TOML reading helper for pincer.toml / pincer.local.toml loaders.
+
+Split out of `pincer.mcp.config` so config-layer loaders (e.g.
+`pincer.config.identity`) can read the same two files without importing
+from `pincer.mcp`, a higher-level package.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+
+def read_toml_raw(toml_path: Path) -> dict[str, Any] | None:
+    """Read a TOML file and return the parsed dict. Returns None if absent or no TOML parser."""
+    if not toml_path.exists():
+        logger.warning(f"Pincer {toml_path} not found. Ommit it")
+        return None
+    try:
+        import tomllib  # Python 3.11+
+    except ImportError:
+        try:
+            import tomli as tomllib  # type: ignore[no-redef]
+        except ImportError:
+            return None
+
+    with open(toml_path, "rb") as f:
+        return tomllib.load(f)  # type: ignore[return-value]

--- a/src/pincer/config/toml_loader.py
+++ b/src/pincer/config/toml_loader.py
@@ -19,7 +19,7 @@ logger = logging.getLogger(__name__)
 def read_toml_raw(toml_path: Path) -> dict[str, Any] | None:
     """Read a TOML file and return the parsed dict. Returns None if absent or no TOML parser."""
     if not toml_path.exists():
-        logger.warning(f"Pincer {toml_path} not found. Ommit it")
+        logger.debug(f"Pincer {toml_path} not found, omitting it")
         return None
     try:
         import tomllib  # Python 3.11+

--- a/src/pincer/core/identity.py
+++ b/src/pincer/core/identity.py
@@ -29,6 +29,18 @@ The optional name prefix sets the pincer_user_id directly (e.g. "user:john" in
 memory tags) instead of the auto-generated "user:usr_abc123..." hash.
 Memory stored under a named ID is portable across DB rebuilds as long as the
 config entry stays the same.
+
+Config mapping (pincer.toml / pincer.local.toml)
+-------------------------------------------------
+For rosters too large to comfortably manage as one PINCER_IDENTITY_MAP
+string, the same mapping can be expressed as a `[identity]` TOML section
+instead — see `pincer.config.identity` for the schema. PINCER_IDENTITY_MAP,
+when set, always takes full precedence over the TOML section (no merging
+between the two). `pincer.config.identity.resolve_identity_map_config`
+converts TOML entries into two things: this module's own string grammar
+(channel-linking, same as PINCER_IDENTITY_MAP) and a `pincer_user_id ->
+IdentityProfile` dict for the fields that string grammar has no room for
+(display_name, preferred_channel, email, timezone) — see `IdentityProfile`.
 """
 
 from __future__ import annotations
@@ -36,6 +48,7 @@ from __future__ import annotations
 import asyncio
 import hashlib
 import logging
+from dataclasses import dataclass
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import TYPE_CHECKING
@@ -54,12 +67,34 @@ logger = logging.getLogger(__name__)
 _PHONE_CHANNELS = {ChannelType.WHATSAPP, ChannelType.VOICE, ChannelType.SIGNAL}
 
 
+@dataclass(frozen=True)
+class IdentityProfile:
+    """Optional profile fields sourced from the [identity] TOML section (see
+    `pincer.config.identity`) — PINCER_IDENTITY_MAP's string grammar has no
+    field for any of these, so entries seeded from the env var never get a
+    profile and these all stay unset. All fields are optional; a profile
+    with everything None is valid (e.g. a TOML person entry that only sets
+    channels).
+    """
+
+    display_name: str | None = None
+    preferred_channel: str | None = None
+    email: str | None = None
+    timezone: str | None = None
+
+
 class IdentityResolver:
     """Resolves channel-specific user IDs to a unified Pincer user ID."""
 
-    def __init__(self, db_path: Path, identity_map_config: str = "") -> None:
+    def __init__(
+        self,
+        db_path: Path,
+        identity_map_config: str = "",
+        profiles: dict[str, IdentityProfile] | None = None,
+    ) -> None:
         self._db_path = str(db_path)
         self._identity_map_config = identity_map_config
+        self._profiles = profiles or {}
 
     @property
     def has_config(self) -> bool:
@@ -441,10 +476,29 @@ class IdentityResolver:
                         pincer_uid = self._generate_user_id(first_ch_type, first_norm)
 
                 first_channel = resolved[0][0]
+                profile = self._profiles.get(pincer_uid, IdentityProfile())
+                preferred_channel = profile.preferred_channel or first_channel
                 await db.execute(
-                    "INSERT OR IGNORE INTO identity_meta (pincer_user_id, preferred_channel) VALUES (?, ?)",
-                    (pincer_uid, first_channel),
+                    "INSERT OR IGNORE INTO identity_meta "
+                    "(pincer_user_id, preferred_channel, display_name, email, timezone) VALUES (?, ?, ?, ?, ?)",
+                    (pincer_uid, preferred_channel, profile.display_name, profile.email, profile.timezone),
                 )
+                if profile != IdentityProfile():
+                    # INSERT OR IGNORE above is a no-op for an identity that already
+                    # existed (e.g. created earlier via resolve()); COALESCE here
+                    # backfills profile fields onto it without clobbering an
+                    # existing value with NULL when only some are set. preferred_channel
+                    # is otherwise write-once (see touch_active_channel's docstring for
+                    # why active_channel, not this, tracks day-to-day channel use).
+                    await db.execute(
+                        "UPDATE identity_meta SET "
+                        "display_name = COALESCE(?, display_name), "
+                        "preferred_channel = COALESCE(?, preferred_channel), "
+                        "email = COALESCE(?, email), "
+                        "timezone = COALESCE(?, timezone) "
+                        "WHERE pincer_user_id = ?",
+                        (profile.display_name, profile.preferred_channel, profile.email, profile.timezone, pincer_uid),
+                    )
                 for ch_str, _ch_type, norm in resolved:
                     await db.execute(
                         "INSERT OR IGNORE INTO channel_identities "

--- a/src/pincer/core/identity.py
+++ b/src/pincer/core/identity.py
@@ -360,6 +360,13 @@ class IdentityResolver:
                     norm = await self._resolve_via_channel(ch_type, norm, channels)
                 allowed.add((ch, norm))
 
+        if not allowed:
+            logger.error(
+                "Identity config produced no usable channel:id pairs — "
+                "skipping cleanup to avoid wiping the identity tables"
+            )
+            return
+
         async with self._get_db() as db:
             cursor = await db.execute("SELECT name FROM sqlite_master WHERE type='table' AND name='identity_meta'")
             if not await cursor.fetchone():

--- a/src/pincer/db/migrations/versions/0004_identity_contact_fields.py
+++ b/src/pincer/db/migrations/versions/0004_identity_contact_fields.py
@@ -1,0 +1,51 @@
+"""Add email/timezone columns to identity_meta.
+
+Populated only via the [identity] TOML config section (see
+pincer.config.identity) — PINCER_IDENTITY_MAP's string grammar
+(`name@ch1:id1=ch2:id2...`) has no field for these, so entries seeded from
+the env var leave them NULL.
+
+Revision ID: 0004
+Revises: 0003
+Create Date: 2026-08-22
+"""
+
+from __future__ import annotations
+
+from alembic import op
+from sqlalchemy import text
+
+revision = "0004"
+down_revision = "0003"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    dialect = bind.dialect.name
+
+    if dialect == "postgresql":
+        op.execute("ALTER TABLE identity_meta ADD COLUMN IF NOT EXISTS email TEXT")
+        op.execute("ALTER TABLE identity_meta ADD COLUMN IF NOT EXISTS timezone TEXT")
+        return
+
+    existing = {row[1] for row in bind.execute(text("PRAGMA table_info(identity_meta)")).fetchall()}
+    if "email" not in existing:
+        op.execute("ALTER TABLE identity_meta ADD COLUMN email TEXT")
+    if "timezone" not in existing:
+        op.execute("ALTER TABLE identity_meta ADD COLUMN timezone TEXT")
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    dialect = bind.dialect.name
+
+    if dialect == "postgresql":
+        op.execute("ALTER TABLE identity_meta DROP COLUMN IF EXISTS email")
+        op.execute("ALTER TABLE identity_meta DROP COLUMN IF EXISTS timezone")
+        return
+
+    # SQLite can't drop columns without a full table rebuild; not worth it
+    # here since 0001's downgrade("base") already drops identity_meta
+    # entirely, taking these columns with it.

--- a/src/pincer/mcp/config.py
+++ b/src/pincer/mcp/config.py
@@ -29,7 +29,6 @@ Environment variable format for a single server:
 
 from __future__ import annotations
 
-import logging
 import os
 import re
 from dataclasses import dataclass, field
@@ -37,10 +36,10 @@ from enum import StrEnum
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
+from pincer.config.toml_loader import read_toml_raw as _read_toml_raw
+
 if TYPE_CHECKING:
     from pincer.config.main import Settings
-
-logger = logging.getLogger(__name__)
 
 # Mirrors Settings.model_config["env_file"] in pincer/config/main.py: ".env" takes
 # priority over "../.env" (monorepo layout — commands run from a subdirectory
@@ -274,23 +273,6 @@ def _parse_server_from_toml(raw: dict[str, Any], pincer_vars: dict[str, str] | N
         startup_timeout=int(raw.get("startup_timeout", 30)),
         max_retries=int(raw.get("max_retries", 2)),
     )
-
-
-def _read_toml_raw(toml_path: Path) -> dict[str, Any] | None:
-    """Read a TOML file and return the parsed dict. Returns None if absent or no TOML parser."""
-    if not toml_path.exists():
-        logger.warning(f"Pincer {toml_path} not found. Ommit it")
-        return None
-    try:
-        import tomllib  # Python 3.11+
-    except ImportError:
-        try:
-            import tomli as tomllib  # type: ignore[no-redef]
-        except ImportError:
-            return None
-
-    with open(toml_path, "rb") as f:
-        return tomllib.load(f)  # type: ignore[return-value]
 
 
 _STDIO_ONLY_KEYS = {"command", "args", "env"}

--- a/src/pincer/security/doctor.py
+++ b/src/pincer/security/doctor.py
@@ -399,7 +399,7 @@ class SecurityDoctor:
 
     # Minimum neonize release carrying a whatsmeow build WhatsApp still accepts.
     # Bump when upstream ships a fix for a fresh `err-client-outdated` wave.
-    _WA_NEONIZE_MIN = (0, 3, 16)
+    _WA_NEONIZE_MIN = (0, 4, 3)
 
     def _check_whatsapp_neonize_version(self) -> CheckResult:
         try:

--- a/tests/test_db_migrations.py
+++ b/tests/test_db_migrations.py
@@ -139,6 +139,18 @@ def test_legacy_identity_map_is_migrated_and_dropped(tmp_path: Path) -> None:
         con.close()
 
 
+def test_identity_meta_has_email_timezone_columns(tmp_path: Path) -> None:
+    db_path = tmp_path / "pincer.db"
+    ensure_schema_current(db_path)
+
+    con = sqlite3.connect(str(db_path))
+    try:
+        cols = {row[1] for row in con.execute("PRAGMA table_info(identity_meta)").fetchall()}
+    finally:
+        con.close()
+    assert {"email", "timezone"} <= cols
+
+
 def test_legacy_audit_db_is_imported_into_unified_db(tmp_path: Path) -> None:
     db_path = tmp_path / "pincer.db"
     legacy_audit_path = tmp_path / "audit.db"

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -286,12 +286,12 @@ def test_whatsapp_neonize_version_passes_on_recent(monkeypatch):
     from types import ModuleType
 
     fake = ModuleType("neonize")
-    fake.__version__ = "0.3.16.post0"  # type: ignore[attr-defined]
+    fake.__version__ = "0.4.3.post0"  # type: ignore[attr-defined]
     monkeypatch.setitem(sys.modules, "neonize", fake)
 
     result = SecurityDoctor()._check_whatsapp_neonize_version()
     assert result.status == CheckStatus.PASS
-    assert "0.3.16" in result.message
+    assert "0.4.3" in result.message
 
 
 def test_whatsapp_neonize_version_warns_on_old(monkeypatch):

--- a/tests/test_identity.py
+++ b/tests/test_identity.py
@@ -784,6 +784,26 @@ class TestCleanup:
         r = IdentityResolver(db_path, identity_map_config="telegram:12345=whatsapp:491234567890")
         await r.cleanup()  # must not raise
 
+    async def test_cleanup_skips_wipe_when_config_has_no_usable_pairs(self, tmp_path):
+        """A config string that's non-empty but parses to zero usable pairs (e.g. an
+        empty channel_user_id, as in 'jane@telegram:') must not be treated as an
+        authoritative empty whitelist — that would delete every pre-existing identity."""
+        import aiosqlite
+
+        db_path = tmp_path / "no_usable_pairs.db"
+        r = IdentityResolver(db_path, identity_map_config="jane@telegram:")
+        await r.ensure_table()
+        uid = await r.resolve(ChannelType.TELEGRAM, 12345)
+
+        await r.cleanup()
+
+        async with (
+            aiosqlite.connect(str(db_path)) as db,
+            db.execute("SELECT COUNT(*) FROM channel_identities WHERE channel_user_id = '12345'") as cur,
+        ):
+            assert (await cur.fetchone())[0] == 1
+        assert await r.resolve(ChannelType.TELEGRAM, 12345) == uid
+
 
 @pytest.mark.asyncio
 class TestLegacyMigration:

--- a/tests/test_identity.py
+++ b/tests/test_identity.py
@@ -4,7 +4,7 @@ import pytest
 import pytest_asyncio
 
 from pincer.channels.base import ChannelType
-from pincer.core.identity import IdentityResolver
+from pincer.core.identity import IdentityProfile, IdentityResolver
 
 
 @pytest_asyncio.fixture
@@ -67,11 +67,11 @@ class TestIdentityResolver:
         """A single channel:id pair (no linking) resolves via _check_config_mapping,
         without needing seed_from_config() to run first."""
         db_path = tmp_path / "single_pair.db"
-        r = IdentityResolver(db_path, identity_map_config="tamias@telegram:559020")
+        r = IdentityResolver(db_path, identity_map_config="johndoe@telegram:100100")
         await r.ensure_table()
 
-        uid = await r.resolve(ChannelType.TELEGRAM, 559020)
-        assert uid == "tamias"
+        uid = await r.resolve(ChannelType.TELEGRAM, 100100)
+        assert uid == "johndoe"
 
     async def test_get_preferred_channel(self, resolver):
         uid = await resolver.resolve(ChannelType.TELEGRAM, 55555)
@@ -558,14 +558,85 @@ class TestNamedCanonicalId:
     async def test_single_channel_named_entry_seeds_identity(self, tmp_path):
         """A single channel:id pair — no linking partner needed — seeds a named identity."""
         db_path = tmp_path / "single_seed.db"
-        r = IdentityResolver(db_path, identity_map_config="tamias@telegram:559020")
+        r = IdentityResolver(db_path, identity_map_config="johndoe@telegram:100100")
         await r.ensure_table()
         await r.seed_from_config()
 
-        assert await r.resolve(ChannelType.TELEGRAM, 559020) == "tamias"
-        ch_type, chat_id = await r.get_preferred_channel("tamias")
+        assert await r.resolve(ChannelType.TELEGRAM, 100100) == "johndoe"
+        ch_type, chat_id = await r.get_preferred_channel("johndoe")
         assert ch_type == ChannelType.TELEGRAM
-        assert chat_id == "559020"
+        assert chat_id == "100100"
+
+    async def test_profile_persisted_on_seed(self, tmp_path):
+        """A profile (TOML-sourced display_name/preferred_channel/email/timezone) is written on seed_from_config."""
+        import aiosqlite
+
+        db_path = tmp_path / "profile.db"
+        r = IdentityResolver(
+            db_path,
+            identity_map_config="johndoe@telegram:100100=whatsapp:491234567890",
+            profiles={
+                "johndoe": IdentityProfile(
+                    display_name="John Doe",
+                    preferred_channel="whatsapp",
+                    email="johndoe@example.com",
+                    timezone="Europe/Berlin",
+                )
+            },
+        )
+        await r.ensure_table()
+        await r.seed_from_config()
+
+        async with aiosqlite.connect(str(db_path)) as db:
+            cursor = await db.execute(
+                "SELECT display_name, preferred_channel, email, timezone "
+                "FROM identity_meta WHERE pincer_user_id = 'johndoe'",
+            )
+            row = await cursor.fetchone()
+        assert row == ("John Doe", "whatsapp", "johndoe@example.com", "Europe/Berlin")
+
+    async def test_profile_without_preferred_channel_falls_back_to_first_pair(self, tmp_path):
+        """A profile that leaves preferred_channel unset doesn't override the first channel:id pair."""
+        import aiosqlite
+
+        db_path = tmp_path / "profile_no_preferred.db"
+        r = IdentityResolver(
+            db_path,
+            identity_map_config="johndoe@telegram:100100=whatsapp:491234567890",
+            profiles={"johndoe": IdentityProfile(display_name="John Doe")},
+        )
+        await r.ensure_table()
+        await r.seed_from_config()
+
+        async with aiosqlite.connect(str(db_path)) as db:
+            cursor = await db.execute(
+                "SELECT preferred_channel FROM identity_meta WHERE pincer_user_id = 'johndoe'",
+            )
+            row = await cursor.fetchone()
+        assert row == ("telegram",)
+
+    async def test_profile_backfilled_onto_existing_identity(self, tmp_path):
+        """Profile fields are backfilled via COALESCE even if the identity row already existed."""
+        import aiosqlite
+
+        db_path = tmp_path / "profile_backfill.db"
+        r_first = IdentityResolver(db_path, identity_map_config="johndoe@telegram:100100")
+        await r_first.ensure_table()
+        await r_first.resolve(ChannelType.TELEGRAM, 100100)  # creates the identity with no profile
+
+        r_second = IdentityResolver(
+            db_path,
+            identity_map_config="johndoe@telegram:100100",
+            profiles={"johndoe": IdentityProfile(email="johndoe@example.com")},
+        )
+        await r_second.seed_from_config()
+
+        async with aiosqlite.connect(str(db_path)) as db:
+            cursor = await db.execute(
+                "SELECT email, timezone FROM identity_meta WHERE pincer_user_id = 'johndoe'",
+            )
+            row = await cursor.fetchone()
+        assert row == ("johndoe@example.com", None)
 
     async def test_unnamed_entry_still_works(self, tmp_path):
         """Entries without a name@ prefix keep the auto-generated hash behavior."""
@@ -590,9 +661,9 @@ class TestNamedCanonicalId:
         assert pairs[0] == ("telegram", "12345")
 
     async def test_parse_mapping_single_pair(self):
-        name, pairs = IdentityResolver._parse_mapping("tamias@telegram:559020")
-        assert name == "tamias"
-        assert pairs == [("telegram", "559020")]
+        name, pairs = IdentityResolver._parse_mapping("johndoe@telegram:100100")
+        assert name == "johndoe"
+        assert pairs == [("telegram", "100100")]
 
     async def test_parse_mapping_empty_raises(self):
         with pytest.raises(ValueError, match="at least 1 channel:id pair"):

--- a/tests/test_identity_api.py
+++ b/tests/test_identity_api.py
@@ -83,6 +83,34 @@ class TestIdentityApi:
         assert data["active_channel"] == "whatsapp"
         assert data["active_channel_updated_at"] is not None
 
+    async def test_list_includes_timezone(self, client: TestClient, resolver: IdentityResolver) -> None:
+        import aiosqlite
+
+        uid = await resolver.resolve(ChannelType.TELEGRAM, 77777)
+        async with aiosqlite.connect(resolver._db_path) as db:
+            await db.execute("UPDATE identity_meta SET timezone = ? WHERE pincer_user_id = ?", ("Europe/Berlin", uid))
+            await db.commit()
+
+        with patch("pincer.api.identity.get_settings_relaxed", return_value=_fake_settings(resolver._db_path)):
+            resp = client.get("/api/identity")
+
+        data = resp.json()
+        entry = next(i for i in data["identities"] if i["pincer_user_id"] == uid)
+        assert entry["timezone"] == "Europe/Berlin"
+
+    async def test_get_single_identity_includes_timezone(self, client: TestClient, resolver: IdentityResolver) -> None:
+        import aiosqlite
+
+        uid = await resolver.resolve(ChannelType.TELEGRAM, 88888)
+        async with aiosqlite.connect(resolver._db_path) as db:
+            await db.execute("UPDATE identity_meta SET timezone = ? WHERE pincer_user_id = ?", ("Europe/Berlin", uid))
+            await db.commit()
+
+        with patch("pincer.api.identity.get_settings_relaxed", return_value=_fake_settings(resolver._db_path)):
+            resp = client.get(f"/api/identity/{uid}")
+
+        assert resp.json()["timezone"] == "Europe/Berlin"
+
     async def test_search_includes_active_channel_fields(self, client: TestClient, resolver: IdentityResolver) -> None:
         uid = await resolver.resolve(ChannelType.TELEGRAM, 66666)
         await resolver.touch_active_channel(uid, ChannelType.TELEGRAM)

--- a/tests/test_identity_api.py
+++ b/tests/test_identity_api.py
@@ -111,6 +111,38 @@ class TestIdentityApi:
 
         assert resp.json()["timezone"] == "Europe/Berlin"
 
+    async def test_list_includes_email(self, client: TestClient, resolver: IdentityResolver) -> None:
+        import aiosqlite
+
+        uid = await resolver.resolve(ChannelType.TELEGRAM, 79797)
+        async with aiosqlite.connect(resolver._db_path) as db:
+            await db.execute(
+                "UPDATE identity_meta SET email = ? WHERE pincer_user_id = ?", ("jane@example.com", uid)
+            )
+            await db.commit()
+
+        with patch("pincer.api.identity.get_settings_relaxed", return_value=_fake_settings(resolver._db_path)):
+            resp = client.get("/api/identity")
+
+        data = resp.json()
+        entry = next(i for i in data["identities"] if i["pincer_user_id"] == uid)
+        assert entry["email"] == "jane@example.com"
+
+    async def test_get_single_identity_includes_email(self, client: TestClient, resolver: IdentityResolver) -> None:
+        import aiosqlite
+
+        uid = await resolver.resolve(ChannelType.TELEGRAM, 89898)
+        async with aiosqlite.connect(resolver._db_path) as db:
+            await db.execute(
+                "UPDATE identity_meta SET email = ? WHERE pincer_user_id = ?", ("jane@example.com", uid)
+            )
+            await db.commit()
+
+        with patch("pincer.api.identity.get_settings_relaxed", return_value=_fake_settings(resolver._db_path)):
+            resp = client.get(f"/api/identity/{uid}")
+
+        assert resp.json()["email"] == "jane@example.com"
+
     async def test_search_includes_active_channel_fields(self, client: TestClient, resolver: IdentityResolver) -> None:
         uid = await resolver.resolve(ChannelType.TELEGRAM, 66666)
         await resolver.touch_active_channel(uid, ChannelType.TELEGRAM)

--- a/tests/test_identity_api.py
+++ b/tests/test_identity_api.py
@@ -116,9 +116,7 @@ class TestIdentityApi:
 
         uid = await resolver.resolve(ChannelType.TELEGRAM, 79797)
         async with aiosqlite.connect(resolver._db_path) as db:
-            await db.execute(
-                "UPDATE identity_meta SET email = ? WHERE pincer_user_id = ?", ("jane@example.com", uid)
-            )
+            await db.execute("UPDATE identity_meta SET email = ? WHERE pincer_user_id = ?", ("jane@example.com", uid))
             await db.commit()
 
         with patch("pincer.api.identity.get_settings_relaxed", return_value=_fake_settings(resolver._db_path)):
@@ -133,9 +131,7 @@ class TestIdentityApi:
 
         uid = await resolver.resolve(ChannelType.TELEGRAM, 89898)
         async with aiosqlite.connect(resolver._db_path) as db:
-            await db.execute(
-                "UPDATE identity_meta SET email = ? WHERE pincer_user_id = ?", ("jane@example.com", uid)
-            )
+            await db.execute("UPDATE identity_meta SET email = ? WHERE pincer_user_id = ?", ("jane@example.com", uid))
             await db.commit()
 
         with patch("pincer.api.identity.get_settings_relaxed", return_value=_fake_settings(resolver._db_path)):

--- a/tests/test_identity_config.py
+++ b/tests/test_identity_config.py
@@ -1,0 +1,307 @@
+"""Tests for the [identity] TOML config section (pincer.config.identity)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from pincer.config.identity import (
+    IdentityTomlEntry,
+    load_identity_config,
+    resolve_identity_map_config,
+)
+from pincer.core.identity import IdentityProfile, IdentityResolver
+
+# ── load_identity_config: basic parsing ─────────────────────────────────────
+
+
+def test_no_config_files_returns_empty(tmp_path: Path) -> None:
+    assert load_identity_config(tmp_path) == {}
+
+
+def test_single_person_single_channel(tmp_path: Path) -> None:
+    (tmp_path / "pincer.toml").write_text("""
+[identity.johndoe]
+display_name      = "John Doe"
+email             = "john.doe@domain.tld"
+timezone          = "Europe/Berlin"
+preferred_channel = "telegram"
+
+[[identity.johndoe.channels]]
+channel         = "telegram"
+channel_user_id = 123456
+""")
+    entries = load_identity_config(tmp_path)
+    assert set(entries) == {"johndoe"}
+    entry = entries["johndoe"]
+    assert entry == IdentityTomlEntry(
+        pincer_user_id="johndoe",
+        display_name="John Doe",
+        preferred_channel="telegram",
+        email="john.doe@domain.tld",
+        timezone="Europe/Berlin",
+        channels=[("telegram", "123456")],
+    )
+
+
+def test_channel_user_id_coerced_to_string(tmp_path: Path) -> None:
+    """TOML allows a bare int or a quoted string for channel_user_id; both normalize to str."""
+    (tmp_path / "pincer.toml").write_text("""
+[identity.jane]
+[[identity.jane.channels]]
+channel         = "telegram"
+channel_user_id = "janeAustin"
+
+[[identity.jane.channels]]
+channel         = "whatsapp"
+channel_user_id = 491111111111
+""")
+    entries = load_identity_config(tmp_path)
+    assert entries["jane"].channels == [("telegram", "janeAustin"), ("whatsapp", "491111111111")]
+
+
+def test_multiple_people(tmp_path: Path) -> None:
+    (tmp_path / "pincer.toml").write_text("""
+[identity.johndoe]
+[[identity.johndoe.channels]]
+channel = "telegram"
+channel_user_id = 1
+
+[identity.jane]
+[[identity.jane.channels]]
+channel = "whatsapp"
+channel_user_id = 2
+""")
+    entries = load_identity_config(tmp_path)
+    assert set(entries) == {"johndoe", "jane"}
+
+
+# ── validation ───────────────────────────────────────────────────────────────
+
+
+def test_unknown_channel_raises(tmp_path: Path) -> None:
+    (tmp_path / "pincer.toml").write_text("""
+[identity.johndoe]
+[[identity.johndoe.channels]]
+channel = "carrier_pigeon"
+channel_user_id = 1
+""")
+    with pytest.raises(ValueError, match="unknown channel"):
+        load_identity_config(tmp_path)
+
+
+def test_unknown_preferred_channel_raises(tmp_path: Path) -> None:
+    (tmp_path / "pincer.toml").write_text("""
+[identity.johndoe]
+preferred_channel = "carrier_pigeon"
+[[identity.johndoe.channels]]
+channel = "telegram"
+channel_user_id = 1
+""")
+    with pytest.raises(ValueError, match="unknown preferred_channel"):
+        load_identity_config(tmp_path)
+
+
+def test_invalid_person_key_raises(tmp_path: Path) -> None:
+    """Bare TOML keys allow hyphens, but the resulting string must round-trip
+    through PINCER_IDENTITY_MAP's 'name@ch:id' grammar, which uses '-' fine but
+    reserves '@'/'='/',' — reject anything outside alphanumeric/underscore,
+    mirroring MCPServerConfig's name validation."""
+    (tmp_path / "pincer.toml").write_text("""
+[identity.john-doe]
+[[identity.john-doe.channels]]
+channel = "telegram"
+channel_user_id = 1
+""")
+    with pytest.raises(ValueError, match="alphanumeric"):
+        load_identity_config(tmp_path)
+
+
+def test_duplicate_channel_pair_across_people_raises(tmp_path: Path) -> None:
+    (tmp_path / "pincer.toml").write_text("""
+[identity.johndoe]
+[[identity.johndoe.channels]]
+channel = "telegram"
+channel_user_id = 1
+
+[identity.jane]
+[[identity.jane.channels]]
+channel = "telegram"
+channel_user_id = 1
+""")
+    with pytest.raises(ValueError, match="already used by identity.johndoe"):
+        load_identity_config(tmp_path)
+
+
+def test_single_channel_entry_is_allowed(tmp_path: Path) -> None:
+    """Unlike PINCER_IDENTITY_MAP's typical usage, a TOML person may have just one channel."""
+    (tmp_path / "pincer.toml").write_text("""
+[identity.johndoe]
+[[identity.johndoe.channels]]
+channel = "telegram"
+channel_user_id = 1
+""")
+    entries = load_identity_config(tmp_path)
+    assert entries["johndoe"].channels == [("telegram", "1")]
+
+
+# ── pincer.toml + pincer.local.toml per-field merge ─────────────────────────
+
+
+def test_local_toml_partial_override_keeps_base_channels(tmp_path: Path) -> None:
+    (tmp_path / "pincer.toml").write_text("""
+[identity.johndoe]
+display_name = "John"
+[[identity.johndoe.channels]]
+channel = "telegram"
+channel_user_id = 1
+""")
+    (tmp_path / "pincer.local.toml").write_text("""
+[identity.johndoe]
+display_name = "Johnny"
+""")
+    entries = load_identity_config(tmp_path)
+    entry = entries["johndoe"]
+    assert entry.display_name == "Johnny"
+    assert entry.channels == [("telegram", "1")]
+
+
+def test_local_toml_replaces_channels_wholesale(tmp_path: Path) -> None:
+    (tmp_path / "pincer.toml").write_text("""
+[identity.johndoe]
+[[identity.johndoe.channels]]
+channel = "telegram"
+channel_user_id = 1
+""")
+    (tmp_path / "pincer.local.toml").write_text("""
+[identity.johndoe]
+[[identity.johndoe.channels]]
+channel = "whatsapp"
+channel_user_id = 2
+""")
+    entries = load_identity_config(tmp_path)
+    # Local's channels list fully replaces base's — not merged per-channel.
+    assert entries["johndoe"].channels == [("whatsapp", "2")]
+
+
+def test_local_toml_adds_new_person(tmp_path: Path) -> None:
+    (tmp_path / "pincer.toml").write_text("""
+[identity.johndoe]
+[[identity.johndoe.channels]]
+channel = "telegram"
+channel_user_id = 1
+""")
+    (tmp_path / "pincer.local.toml").write_text("""
+[identity.jane]
+[[identity.jane.channels]]
+channel = "whatsapp"
+channel_user_id = 2
+""")
+    entries = load_identity_config(tmp_path)
+    assert set(entries) == {"johndoe", "jane"}
+
+
+def test_local_toml_only_no_base(tmp_path: Path) -> None:
+    (tmp_path / "pincer.local.toml").write_text("""
+[identity.johndoe]
+[[identity.johndoe.channels]]
+channel = "telegram"
+channel_user_id = 1
+""")
+    entries = load_identity_config(tmp_path)
+    assert set(entries) == {"johndoe"}
+
+
+# ── resolve_identity_map_config: env-var precedence + stringification ──────
+
+
+def test_env_var_short_circuits_toml(tmp_path: Path) -> None:
+    (tmp_path / "pincer.toml").write_text("""
+[identity.johndoe]
+[[identity.johndoe.channels]]
+channel = "telegram"
+channel_user_id = 1
+""")
+    config, profiles = resolve_identity_map_config("jane@telegram:2=whatsapp:3", tmp_path)
+    assert config == "jane@telegram:2=whatsapp:3"
+    assert profiles == {}
+
+
+def test_no_env_var_stringifies_toml_entries(tmp_path: Path) -> None:
+    (tmp_path / "pincer.toml").write_text("""
+[identity.johndoe]
+[[identity.johndoe.channels]]
+channel = "telegram"
+channel_user_id = 123456
+
+[[identity.johndoe.channels]]
+channel = "whatsapp"
+channel_user_id = "491234567890"
+""")
+    config, _ = resolve_identity_map_config("", tmp_path)
+    assert config == "johndoe@telegram:123456=whatsapp:491234567890"
+
+
+def test_stringified_config_round_trips_through_parse_mapping(tmp_path: Path) -> None:
+    """The stringified TOML output must be understood by IdentityResolver._parse_mapping unchanged."""
+    (tmp_path / "pincer.toml").write_text("""
+[identity.johndoe]
+[[identity.johndoe.channels]]
+channel = "telegram"
+channel_user_id = 123456
+
+[identity.jane]
+[[identity.jane.channels]]
+channel = "telegram"
+channel_user_id = "janeAustin"
+
+[[identity.jane.channels]]
+channel = "whatsapp"
+channel_user_id = "491111111111"
+""")
+    config, _ = resolve_identity_map_config("", tmp_path)
+    entries = [IdentityResolver._parse_mapping(raw) for raw in config.split(",")]
+    assert entries == [
+        ("johndoe", [("telegram", "123456")]),
+        ("jane", [("telegram", "janeAustin"), ("whatsapp", "491111111111")]),
+    ]
+
+
+def test_profiles_carry_display_name_preferred_channel_email_timezone(tmp_path: Path) -> None:
+    (tmp_path / "pincer.toml").write_text("""
+[identity.johndoe]
+display_name = "John Doe"
+preferred_channel = "whatsapp"
+email = "john.doe@domain.tld"
+timezone = "Europe/Berlin"
+[[identity.johndoe.channels]]
+channel = "telegram"
+channel_user_id = 1
+
+[[identity.johndoe.channels]]
+channel = "whatsapp"
+channel_user_id = 2
+
+[identity.jane]
+[[identity.jane.channels]]
+channel = "telegram"
+channel_user_id = 3
+""")
+    _, profiles = resolve_identity_map_config("", tmp_path)
+    assert profiles["johndoe"] == IdentityProfile(
+        display_name="John Doe",
+        preferred_channel="whatsapp",
+        email="john.doe@domain.tld",
+        timezone="Europe/Berlin",
+    )
+    # A person with no profile fields set still gets an (all-None) entry —
+    # resolve_identity_map_config doesn't filter people out, it's up to the
+    # caller (IdentityResolver.seed_from_config) to treat that as a no-op.
+    assert profiles["jane"] == IdentityProfile()
+
+
+def test_no_config_no_env_returns_empty(tmp_path: Path) -> None:
+    config, profiles = resolve_identity_map_config("", tmp_path)
+    assert config == ""
+    assert profiles == {}

--- a/tests/test_identity_config.py
+++ b/tests/test_identity_config.py
@@ -157,6 +157,34 @@ channel = "telegram"
         load_identity_config(tmp_path)
 
 
+def test_empty_channel_user_id_raises(tmp_path: Path) -> None:
+    """An empty string channel_user_id must be rejected: str("") is still "",
+    so it would otherwise pass the "needs at least one channel" guard while
+    stringifying to 'jane@telegram:' — a segment that survives IdentityResolver's
+    skip-guards but yields zero usable pairs, hitting the same empty-whitelist
+    wipe as test_channelless_entry_raises."""
+    (tmp_path / "pincer.toml").write_text("""
+[identity.jane]
+[[identity.jane.channels]]
+channel         = "telegram"
+channel_user_id = ""
+""")
+    with pytest.raises(ValueError, match="identity.jane: channel 'telegram' has an empty channel_user_id"):
+        load_identity_config(tmp_path)
+
+
+def test_whitespace_only_channel_user_id_raises(tmp_path: Path) -> None:
+    """Whitespace-only channel_user_id is stripped to empty and rejected the same way."""
+    (tmp_path / "pincer.toml").write_text("""
+[identity.jane]
+[[identity.jane.channels]]
+channel         = "telegram"
+channel_user_id = "   "
+""")
+    with pytest.raises(ValueError, match="identity.jane: channel 'telegram' has an empty channel_user_id"):
+        load_identity_config(tmp_path)
+
+
 def test_single_channel_entry_is_allowed(tmp_path: Path) -> None:
     """Unlike PINCER_IDENTITY_MAP's typical usage, a TOML person may have just one channel."""
     (tmp_path / "pincer.toml").write_text("""

--- a/tests/test_identity_config.py
+++ b/tests/test_identity_config.py
@@ -134,6 +134,29 @@ channel_user_id = 1
         load_identity_config(tmp_path)
 
 
+def test_channelless_entry_raises(tmp_path: Path) -> None:
+    """A person with zero [[channels]] entries must be rejected: stringified via
+    PINCER_IDENTITY_MAP's grammar it becomes non-empty ("jane@"), which flips
+    IdentityResolver.has_config to True and makes cleanup() treat the (empty)
+    resulting whitelist as authoritative — wiping every other identity."""
+    (tmp_path / "pincer.toml").write_text("""
+[identity.jane]
+display_name = "Jane Austin"
+""")
+    with pytest.raises(ValueError, match="needs at least one"):
+        load_identity_config(tmp_path)
+
+
+def test_channel_entry_missing_key_raises_with_context(tmp_path: Path) -> None:
+    (tmp_path / "pincer.toml").write_text("""
+[identity.johndoe]
+[[identity.johndoe.channels]]
+channel = "telegram"
+""")
+    with pytest.raises(ValueError, match="identity.johndoe: channel entry missing 'channel_user_id'"):
+        load_identity_config(tmp_path)
+
+
 def test_single_channel_entry_is_allowed(tmp_path: Path) -> None:
     """Unlike PINCER_IDENTITY_MAP's typical usage, a TOML person may have just one channel."""
     (tmp_path / "pincer.toml").write_text("""

--- a/tests/test_schedule_tool.py
+++ b/tests/test_schedule_tool.py
@@ -63,7 +63,7 @@ class TestScheduleCreate:
                 name="x",
                 cron_expr="0 8 * * *",
                 prompt="p",
-                context={"pincer_user_id": "telegram:559020", "channel_name": "telegram"},
+                context={"pincer_user_id": "telegram:100100", "channel_name": "telegram"},
             )
         assert result.startswith("Error")
         assert "identity isn't fully linked" in result

--- a/uv.lock
+++ b/uv.lock
@@ -3000,7 +3000,7 @@ wheels = [
 
 [[package]]
 name = "neonize"
-version = "0.3.17.post0"
+version = "0.4.3.post0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "httpx" },
@@ -3014,18 +3014,18 @@ dependencies = [
     { name = "segno" },
     { name = "tqdm" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/8f/11/a77128a57ca515032508edbb0f74999d1f2ba7ce4c07311febe42a6f6f54/neonize-0.3.17.post0.tar.gz", hash = "sha256:295360db44d93af7adf0fffca89a1976473c4cb4b2f41c0522c5d6057fd78208", size = 467437, upload-time = "2026-04-24T13:52:52.652Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/3f/e9/f611667c8b6bfb80b37c1a84b8694157c18c61db5705fa379b7fe7b5a24c/neonize-0.4.3.post0.tar.gz", hash = "sha256:659feb762ce9f3e9c1c2c359b3adfefe93e4cb746d03d6f4ec53f853a1e8414c", size = 502861, upload-time = "2026-07-12T09:35:36.509Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/df/f7/13c5cb9a187d3e8551ff3a694b3d4bfda0bef56c06cf7b9790956de08617/neonize-0.3.17.post0-py3-none-any.whl", hash = "sha256:f46425295fe2ef6293865e31f4f5dbb504d7c40d9ada75ffb67ad0c994916cbf", size = 562302, upload-time = "2026-04-24T13:52:51.523Z" },
-    { url = "https://files.pythonhosted.org/packages/32/8e/58558e28638822be432936850390560aa82921862e12384d5e947e863f17/neonize-0.3.17.post0-py310-none-macosx_12_0_arm64.whl", hash = "sha256:0411938f134252e2e2eec689dc670a211b266689edf4a1764b049785a452ca3a", size = 6191462, upload-time = "2026-04-24T13:47:20.471Z" },
-    { url = "https://files.pythonhosted.org/packages/49/e9/71abf2785e50343f8bea8309f6b686e45154db539a3a0bf10b30608d3197/neonize-0.3.17.post0-py310-none-macosx_12_0_x86_64.whl", hash = "sha256:e5e22b77e08d6e507398ea5f5e2939ff1bc1c3a6cc078e60dab530062d291aeb", size = 6601083, upload-time = "2026-04-24T13:47:18.361Z" },
-    { url = "https://files.pythonhosted.org/packages/89/5d/25a5c5c469429c9700510687c77aaf2820367f48fbf6ce833b77e13fae70/neonize-0.3.17.post0-py310-none-manylinux2014_aarch64.whl", hash = "sha256:454cb1146f9828e98511d944697592cddde8b43b5b4cf2bc86479629bc53bea6", size = 6406078, upload-time = "2026-04-24T13:50:57.473Z" },
-    { url = "https://files.pythonhosted.org/packages/53/50/a15acf51283c3da3a296202d90dad62717e77bb0a2f4872a1aade4624bad/neonize-0.3.17.post0-py310-none-manylinux2014_i686.whl", hash = "sha256:c84519b379ae1b69dab01eb01301d7f1f700aec2adc8f9870ff5b0bab0c30b61", size = 9391319, upload-time = "2026-04-24T13:51:49.083Z" },
-    { url = "https://files.pythonhosted.org/packages/59/36/ad072810e7bc7545052842c96374be2332132eb9259bd1904973257e707f/neonize-0.3.17.post0-py310-none-manylinux2014_s390x.whl", hash = "sha256:055c1ba40777c44daebf99e4cccbec735d8e808086c165ad2f3c6626a75e3ae7", size = 6891365, upload-time = "2026-04-24T13:50:53.414Z" },
-    { url = "https://files.pythonhosted.org/packages/4e/93/032ef3b167941e0c866fe6f3361e2bb023f2b1bb47948772a50dd009e2da/neonize-0.3.17.post0-py310-none-manylinux2014_x86_64.whl", hash = "sha256:11a643125a1792a765f3deefd3ee92a6459ae23aaf7e5aeeef21dbaf6434458c", size = 6890163, upload-time = "2026-04-24T13:50:55.619Z" },
-    { url = "https://files.pythonhosted.org/packages/d0/62/001d48deac92ec49248b8ebf9dd33872c60398026e108aef7503e7c5ce0c/neonize-0.3.17.post0-py310-none-win32.whl", hash = "sha256:b4c35fe529176815b487694d89f4f07b0f13f522f6f08e2d83402d9860236f51", size = 6709243, upload-time = "2026-04-24T13:51:51.595Z" },
-    { url = "https://files.pythonhosted.org/packages/42/bc/076efc9a48f470c5f3c620b89b157e619cad89f601a81594cccff941b26f/neonize-0.3.17.post0-py310-none-win_amd64.whl", hash = "sha256:5ee96b34f0b05502e4b6e630ac0e8c73c9f5ee6f3b438e8c095e75110dd544db", size = 6806036, upload-time = "2026-04-24T13:51:46.806Z" },
-    { url = "https://files.pythonhosted.org/packages/9b/3b/0bef341b010395dcba7d3e02fd8df4345366efbc1183089f98041641a039/neonize-0.3.17.post0-py310-none-win_arm64.whl", hash = "sha256:7ebce0d2f22dade5aebfab2bebdfe497c77b013936417e394c6c421b09058af1", size = 6200513, upload-time = "2026-04-24T13:51:44.461Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/01/0397619931f5d318ad0670dd527a79bf589d06c57b5ea9da40e1d9d84dd2/neonize-0.4.3.post0-py3-none-any.whl", hash = "sha256:c9ea72794f265e51f3484ba95e5dcedbb399d323e5335820545ff335a81a8129", size = 604187, upload-time = "2026-07-12T09:35:35.262Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/c7/29776da49acfb612c8dcbbce6d75b91452c9d034d8c244dadfa97b05547d/neonize-0.4.3.post0-py310-none-macosx_12_0_arm64.whl", hash = "sha256:16562910a728c82ea749340e8beadc0022468ad7a463ddca7f12071f3ad2cc46", size = 7170385, upload-time = "2026-07-12T09:27:26.587Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/b9/81e408f176d6065ccf3f3f4c8dcec64238304d123e60856e9a4d3f240e8e/neonize-0.4.3.post0-py310-none-macosx_12_0_x86_64.whl", hash = "sha256:dabd4835f15f9381a78a7fece5a00a32d2f85d0f1c83d4ccb72fa4d6693bb569", size = 7654249, upload-time = "2026-07-12T09:27:28.341Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/eb/17094cbcc32b517bad27df6ba32fdf4aa71ff26986ffd0c9cfc0a3c815c3/neonize-0.4.3.post0-py310-none-manylinux2014_aarch64.whl", hash = "sha256:4654bc1157dfbdbc9747ee6786a1703d6c82563f99d60e33c3760fc22f304128", size = 7399556, upload-time = "2026-07-12T09:31:31.621Z" },
+    { url = "https://files.pythonhosted.org/packages/90/13/42872c04e2ff1f8e4e71c08d39a635785f25a383b7302904c3040d55b39c/neonize-0.4.3.post0-py310-none-manylinux2014_i686.whl", hash = "sha256:9fffc6e337f59e149f6580df66cb1796a5acabf8f717ce7762484247f5cd9a05", size = 10693381, upload-time = "2026-07-12T09:34:17.01Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/32/91cd90f2447033399f8c908855cdb084ef2c40e62ab8d2dbf9667f33c833/neonize-0.4.3.post0-py310-none-manylinux2014_s390x.whl", hash = "sha256:4f059081ea7a81eceeaa4486f6ec7fc69b405e09ef75a65c5d18aaa364dd1201", size = 7974851, upload-time = "2026-07-12T09:31:33.664Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/b6/b5376fd3901caafb696ad090cdd48b04f3728ff437efe2dd0515339dc662/neonize-0.4.3.post0-py310-none-manylinux2014_x86_64.whl", hash = "sha256:e5ac977bf6e71f7a11920f3aff86b61fd58acb324325e2cbb884b93426971f08", size = 7977344, upload-time = "2026-07-12T09:31:35.756Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/36/ac17cc7e599cd7991652d8754d71501e6adca30b172acb32a8ff817709f9/neonize-0.4.3.post0-py310-none-win32.whl", hash = "sha256:13b4ff1e4b1a86d8c3d427b41dd49d5735dd87b22edadd9b94b064b53fad9ea7", size = 7783622, upload-time = "2026-07-12T09:34:19.529Z" },
+    { url = "https://files.pythonhosted.org/packages/70/e5/460c0a129c1a4eafd53b78152fb0189b1a458e498c72d9a0f30900ed66ff/neonize-0.4.3.post0-py310-none-win_amd64.whl", hash = "sha256:4c0f4dd3b6592d9c0ba42211d2a28b91a00362ea4278a5de2497a1fdd8ebcc98", size = 7862158, upload-time = "2026-07-12T09:34:21.653Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/08/c693c5c819e16eded9d0b8330fb8a1e905ceb22cbe4fbdbf7d99cce9217d/neonize-0.4.3.post0-py310-none-win_arm64.whl", hash = "sha256:4ba4f252450c0f8abf906c3e45eafb14a5cf93a356923669a012fd66504ad1b7", size = 7142843, upload-time = "2026-07-12T09:34:23.748Z" },
 ]
 
 [[package]]
@@ -3604,7 +3604,7 @@ requires-dist = [
     { name = "microsoft-teams-apps", extras = ["graph"], marker = "extra == 'teams'", specifier = ">=2.0.13.4" },
     { name = "ms365-mcp", marker = "extra == 'mcp'", editable = "src/ms365-mcp" },
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.13.0" },
-    { name = "neonize", specifier = ">=0.3.17" },
+    { name = "neonize", specifier = ">=0.4.3" },
     { name = "openai", specifier = ">=1.60.0" },
     { name = "pincer-agent", extras = ["browser", "memory", "pdf", "pdfgen", "skills", "voice", "image", "mcp", "slack", "teams", "local", "telemetry", "tasks-redis"], marker = "extra == 'all'" },
     { name = "pincer-mcps", marker = "extra == 'mcp'", editable = "src/pincer-mcps" },


### PR DESCRIPTION
…R_IDENTITY_MAP

Lets rosters too large for one PINCER_IDENTITY_MAP string be defined instead as [identity.<key>] tables in pincer.toml/pincer.local.toml, merged per person/per field the same way [[mcp.servers]] already is. PINCER_IDENTITY_MAP, when set, still fully overrides the TOML section.

- New pincer/config/identity.py loader (+ toml_loader.py, hoisted out of pincer/mcp/config.py for reuse) parses, validates, and merges the [identity] section, then converts it into PINCER_IDENTITY_MAP's own string grammar plus an IdentityProfile per person for the fields that grammar has no room for (display_name, preferred_channel, email, timezone). A person with zero [[channels]] entries is now rejected at load time (previously it silently stringified to `"name@"`, which flipped `IdentityResolver.has_config` to `True` and made `cleanup()` wipe every identity in the DB on startup).
- IdentityResolver.seed_from_config persists those profile fields, COALESCE- backfilling onto an already-existing identity without clobbering.
- New Alembic revision 0004 adds identity_meta.email/timezone (Postgres-aware downgrade).
- REST API (/api/identity) now exposes timezone and email.
- Docs and pincer.toml/pincer.local.toml updated with the new schema.

Also bumps `neonize` 0.3.17 → 0.4.3 (`pyproject.toml`, `uv.lock`, `src/pincer/channels/whatsapp.py`, `doctor.py`'s `_WA_NEONIZE_MIN`, `test_doctor.py`) to fix WhatsApp login errors on the older pin — unrelated to the [identity] section but small enough to ride along rather than split into its own PR.

Known follow-up (not in scope here): `identity_meta.email` isn't read anywhere yet beyond the API response, and per-identity `timezone` isn't consumed outside the API either — e.g. `tools/bootstrap.py:467` still falls back to the app-level default timezone rather than the resolved identity's value.

Closes #177
